### PR TITLE
fix(swc): suppress swc output by default

### DIFF
--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -55,6 +55,7 @@ def _impl(ctx):
             "--out-file",
             js_out.path,
             "--no-swcrc",
+            "-q",
         ])
 
         binding = ctx.toolchains["@aspect_rules_swc//swc:toolchain_type"].swcinfo.binding


### PR DESCRIPTION
By default, swc outputs `Successfully compiled 1 file with swc.` when compilation is successful, this extra logging isn't really needed under bazel, and leads to polluted logs when many `swc` rules are used.

Add the `-q` flag by default to quieten down the output, errors will still be printed:

```
$ bazel build //examples/simple:transpile

INFO: Analyzed target //examples/simple:transpile (1 packages loaded, 2 targets configured).
INFO: Found 1 target...
ERROR: /Users/matthew.mackay/robinhood/rules_swc/examples/simple/BUILD.bazel:13:4: Transpiling with swc //examples/simple:transpile [swc examples/simple/in.ts] failed: (Exit 1): _cli_launcher.sh failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/swc/_cli_launcher.sh -q examples/simple/in.ts --out-file bazel-out/darwin-fastbuild/bin/examples/simple/in.js --no-swcrc

Use --sandbox_debug to see verbose messages from the sandbox
error: Unterminated string constant

  |
1 | export const a: string = "simple\";
  |                          ^^^^^^^^^^



Caused by:
    0: failed to process js file
    1: error was recoverable, but proceeding would result in wrong codegen
    2: Syntax Error
Error: Failed to compile 1 file with swc.
    at Object.assertCompilationResult (/private/var/tmp/_bazel_matthew.mackay/6c8ddc134c43bb6cd9b98009b67f8e38/execroot/aspect_rules_swc/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/npm__swc_cli-0.1.52/@swc/cli/lib/swc/util.js:115:15)
    at files (/private/var/tmp/_bazel_matthew.mackay/6c8ddc134c43bb6cd9b98009b67f8e38/execroot/aspect_rules_swc/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/npm__swc_cli-0.1.52/@swc/cli/lib/swc/file.js:175:18)
    at async _default (/private/var/tmp/_bazel_matthew.mackay/6c8ddc134c43bb6cd9b98009b67f8e38/execroot/aspect_rules_swc/bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/npm__swc_cli-0.1.52/@swc/cli/lib/swc/file.js:194:9)
Target //examples/simple:transpile failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.731s, Critical Path: 0.49s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```