### PR TITLE
fix: don't try to declare swc toolchain for target platform

### DIFF
--- a/swc/private/toolchains_repo.bzl
+++ b/swc/private/toolchains_repo.bzl
@@ -123,7 +123,6 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
 toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
-    target_compatible_with = {compatible_with},
     toolchain = "@{user_repository_name}_{platform}//:swc_toolchain",
     toolchain_type = "@aspect_rules_swc//swc:toolchain_type",
 )


### PR DESCRIPTION
The tool is only used in execution context. When this line is included, the build will fail when targetting QNX for example