### PR TITLE
Update github archive URLs to have stable SHAs

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -16,7 +16,7 @@ http_archive(
     name = "aspect_rules_swc",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_swc/archive/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/rules_swc/archive/refs/tags/${TAG}.tar.gz",
 )
 
 # Fetches the rules_swc dependencies.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -49,7 +49,7 @@ def rules_swc_internal_deps():
         strip_prefix = "bazel-skylib-1.1.1",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz",
         ],
     )
 

--- a/swc/dependencies.bzl
+++ b/swc/dependencies.bzl
@@ -35,7 +35,7 @@ def rules_swc_dependencies():
         name = "aspect_bazel_lib",
         sha256 = "e834c368f36cb336b5b42cd1dd9cd4b6bafa0ad3ed7f92f54a47e5ab436e4f59",
         strip_prefix = "bazel-lib-0.3.0",
-        url = "https://github.com/aspect-build/bazel-lib/archive/v0.3.0.tar.gz",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.3.0.tar.gz",
     )
 
     maybe(
@@ -43,5 +43,5 @@ def rules_swc_dependencies():
         name = "aspect_rules_js",
         sha256 = "dd78b4911b7c2e6c6e919b85cd31572cc15e5baa62b9e7354d8a1065c67136e3",
         strip_prefix = "rules_js-0.3.1",
-        url = "https://github.com/aspect-build/rules_js/archive/v0.3.1.tar.gz",
+        url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v0.3.1.tar.gz",
     )


### PR DESCRIPTION
Required per https://github.com/bazel-contrib/SIG-rules-authors/issues/11