### PR TITLE
feat: support srcs with DefaultInfo producing .ts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ load("//swc:repositories.bzl", "swc_register_toolchains")
 
 swc_register_toolchains(
     name = "default_swc",
-    swc_version = "v1.2.119",
+    swc_version = "v1.2.141",
 )
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")

--- a/docs/swc.md
+++ b/docs/swc.md
@@ -16,7 +16,7 @@ swc(name = "transpile")
 ## swc_transpiler
 
 <pre>
-swc_transpiler(<a href="#swc_transpiler-name">name</a>, <a href="#swc_transpiler-args">args</a>, <a href="#swc_transpiler-data">data</a>, <a href="#swc_transpiler-js_outs">js_outs</a>, <a href="#swc_transpiler-map_outs">map_outs</a>, <a href="#swc_transpiler-output_dir">output_dir</a>, <a href="#swc_transpiler-srcs">srcs</a>, <a href="#swc_transpiler-swc_cli">swc_cli</a>, <a href="#swc_transpiler-swcrc">swcrc</a>)
+swc_transpiler(<a href="#swc_transpiler-name">name</a>, <a href="#swc_transpiler-args">args</a>, <a href="#swc_transpiler-data">data</a>, <a href="#swc_transpiler-js_outs">js_outs</a>, <a href="#swc_transpiler-map_outs">map_outs</a>, <a href="#swc_transpiler-output_dir">output_dir</a>, <a href="#swc_transpiler-source_maps">source_maps</a>, <a href="#swc_transpiler-srcs">srcs</a>, <a href="#swc_transpiler-swc_cli">swc_cli</a>, <a href="#swc_transpiler-swcrc">swcrc</a>)
 </pre>
 
 Underlying rule for the `swc` macro.
@@ -37,6 +37,7 @@ for example to set your own output labels for `js_outs`.
 | <a id="swc_transpiler-js_outs"></a>js_outs |  list of expected JavaScript output files.<br><br>There must be one for each entry in srcs, and in the same order.   | List of labels | optional |  |
 | <a id="swc_transpiler-map_outs"></a>map_outs |  list of expected source map output files.<br><br>Can be empty, meaning no source maps should be produced. If non-empty, there must be one for each entry in srcs, and in the same order.   | List of labels | optional |  |
 | <a id="swc_transpiler-output_dir"></a>output_dir |  whether to produce a directory output rather than individual files   | Boolean | optional | False |
+| <a id="swc_transpiler-source_maps"></a>source_maps |  see https://swc.rs/docs/usage/cli#--source-maps--s   | String | optional | "false" |
 | <a id="swc_transpiler-srcs"></a>srcs |  source files, typically .ts files in the source tree   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="swc_transpiler-swc_cli"></a>swc_cli |  binary that executes the swc CLI   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @aspect_rules_swc//swc:cli |
 | <a id="swc_transpiler-swcrc"></a>swcrc |  label of a configuration file for swc, see https://swc.rs/docs/configuration/swcrc   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
@@ -47,7 +48,7 @@ for example to set your own output labels for `js_outs`.
 ## swc
 
 <pre>
-swc(<a href="#swc-name">name</a>, <a href="#swc-srcs">srcs</a>, <a href="#swc-args">args</a>, <a href="#swc-data">data</a>, <a href="#swc-output_dir">output_dir</a>, <a href="#swc-swcrc">swcrc</a>, <a href="#swc-source_maps">source_maps</a>, <a href="#swc-source_map_outputs">source_map_outputs</a>, <a href="#swc-kwargs">kwargs</a>)
+swc(<a href="#swc-name">name</a>, <a href="#swc-srcs">srcs</a>, <a href="#swc-args">args</a>, <a href="#swc-data">data</a>, <a href="#swc-output_dir">output_dir</a>, <a href="#swc-swcrc">swcrc</a>, <a href="#swc-source_maps">source_maps</a>, <a href="#swc-kwargs">kwargs</a>)
 </pre>
 
 Execute the swc compiler
@@ -63,8 +64,7 @@ Execute the swc compiler
 | <a id="swc-data"></a>data |  runtime dependencies to be propagated in the runfiles   |  <code>[]</code> |
 | <a id="swc-output_dir"></a>output_dir |  whether to produce a directory output rather than individual files   |  <code>False</code> |
 | <a id="swc-swcrc"></a>swcrc |  label of a configuration file for swc, see https://swc.rs/docs/configuration/swcrc   |  <code>None</code> |
-| <a id="swc-source_maps"></a>source_maps |  If set, the --source-maps argument is passed to the swc cli with the value. True/False are automaticaly converted to "true"/"false" string values the cli expects. If source_maps is "true" or "both" then source_map_outputs is automatically set to True.   |  <code>None</code> |
-| <a id="swc-source_map_outputs"></a>source_map_outputs |  if the rule is expected to produce a .js.map file output for each .js file output   |  <code>False</code> |
+| <a id="swc-source_maps"></a>source_maps |  If set, the --source-maps argument is passed to the swc cli with the value. See https://swc.rs/docs/usage/cli#--source-maps--s True/False are automaticaly converted to "true"/"false" string values the cli expects.   |  <code>False</code> |
 | <a id="swc-kwargs"></a>kwargs |  additional named parameters like tags or visibility   |  none |
 
 

--- a/examples/custom_outs/BUILD.bazel
+++ b/examples/custom_outs/BUILD.bazel
@@ -6,7 +6,7 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
         name = "transpile_" + format,
         srcs = ["in.ts"],
         args = [
-            "-C",
+            "--config",
             "module.type=" + format,
         ],
         js_outs = [format + "/out." + ("cjs" if format == "commonjs" else "js")],

--- a/examples/filegroup/BUILD.bazel
+++ b/examples/filegroup/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@aspect_rules_swc//swc:swc.bzl", "swc")
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "a.ts",
+        "b.ts",
+    ],
+)
+
+swc(
+    name = "transpile",
+    srcs = ["srcs"],
+    source_maps = "true",
+)
+
+# Since the srcs were in a filegroup, the swc macro cannot pre-declare the outputs.
+# So there is no label ":a.js" that we can reference from the build file.
+# However, a.js is still produced as one of the default outputs of the transpile rule.
+# We can verify this in an action that depends on the ":transpile" rule and reads the files.
+sh_test(
+    name = "check_outputs",
+    srcs = ["check_outputs.sh"],
+    data = [":transpile"],
+)

--- a/examples/filegroup/a.ts
+++ b/examples/filegroup/a.ts
@@ -1,0 +1,1 @@
+export const a: string = "a";

--- a/examples/filegroup/b.ts
+++ b/examples/filegroup/b.ts
@@ -1,0 +1,1 @@
+export const b: string = "b";

--- a/examples/filegroup/check_outputs.sh
+++ b/examples/filegroup/check_outputs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o errexit
+
+cd "$TEST_SRCDIR/$TEST_WORKSPACE/$(dirname $TEST_TARGET)"
+grep "export var a" filegroup/a.js
+grep "sourceMappingURL=a.js.map" filegroup/a.js
+grep "../../../../../examples/filegroup/a.ts" filegroup/a.js.map

--- a/swc/BUILD.bazel
+++ b/swc/BUILD.bazel
@@ -63,6 +63,7 @@ bzl_library(
     deps = [
         "//swc/private:swc",
         "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:types",
     ],
 )
 

--- a/swc/private/versions.bzl
+++ b/swc/private/versions.bzl
@@ -1,6 +1,21 @@
 "Mirror of release info"
 
 TOOL_VERSIONS = {
+    "v1.2.141": {
+        "android-arm-eabi": "sha384-1Kpl5sj2A50yTtZu5Ae7rGGY+t+0FYvcy/VCUp1IM8lW36RuhERqfahcWdmgtinB",
+        "android-arm64": "sha384-F/kmewGo2LlmyIeEQBnctRBJULmcSbko/5Gz1AJNxATWS1JUEX8C06AhdTpV7dk0",
+        "darwin-arm64": "sha384-UoQMYxodChrzQ785r7bo71aBDUqiu8qE8OSlE+64XrQUk7af0E9QfeA/uOKH81I8",
+        "darwin-x64": "sha384-nzfWWp7SHinJEGXyzeDFcprHs30oGJ4Xb6KV1NDPBMItkP37dGif9KQ4vjIcRiM2",
+        "freebsd-x64": "sha384-oS5YYV3h2CkOdPXy0ERp4/33EMn/iBDA353qp7zlSDsfuFpcCjdauFkMEiAwIipi",
+        "linux-arm-gnueabihf": "sha384-Y0xADrA2UwuwQq0OA3dNdjWLIqq4HwPR0lfhai3Ss+BvMDMpsjtSKLek/shav5++",
+        "linux-arm64-gnu": "sha384-lFM98s0YsVi2LRW5W082i+omOvkeOhiDFHWWdv2N91VGGXrmQxrMbhDgR85aPZBZ",
+        "linux-arm64-musl": "sha384-paCvYozCr4y0XQw4wbp5yi00GaAzMo6pqAxUMkYleY3is8H4obpRr48XCXEJ9ouq",
+        "linux-x64-gnu": "sha384-uNw6WyW05qRZhxam2ls9cQRXi9Cmx1+ItQ1+i2CgXuImHHl3lFhnlMCgvvJTdRyL",
+        "linux-x64-musl": "sha384-uzzI2i5JdE8G/zwvQPGeMbemVIwRnnqWExifbcQGNVYQ614Md26Hhriw4Ej9YFRA",
+        "win32-arm64-msvc": "sha384-iBDJmWJVtxouMntcoGrPqpOEZP5OQrXDWPOE1+kIWSvmlC/JDkNhPL0zyiTxX/Bb",
+        "win32-ia32-msvc": "sha384-p9MgHvIpyHbBoRSbvmAe3llF6xTmjTvfPTjc04xoNgMiIL2wCRG5HaPWNEd/10i0",
+        "win32-x64-msvc": "sha384-4t9URv/+EEfnaU1sp9aFnG/CVWD3/biCq18o/MLvKiZw4ZzcRtyqWZz12aL/HDUY",
+    },
     "v1.2.119": {
         "android-arm64": "sha384-whzMbD0maV04vzMdOVfPQNDhpe3gWy9Tyg+SsXbzgA5oZDoqTjTM3e2Y5MeKWnz3",
         "darwin-arm64": "sha384-2E4E13tCxfatne30Ss2FY+o0T8ebMV4gO999oqWPbehFxcaQI/6+D304xGZPF8/x",

--- a/swc/swc.bzl
+++ b/swc/swc.bzl
@@ -10,7 +10,7 @@ swc(name = "transpile")
 """
 
 load("//swc/private:swc.bzl", _swc_lib = "swc")
-load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:types.bzl", "types")
 
 swc_transpiler = rule(
     doc = """Underlying rule for the `swc` macro.
@@ -24,18 +24,7 @@ for example to set your own output labels for `js_outs`.""",
     toolchains = _swc_lib.toolchains,
 )
 
-# In theory, swc can transform .js -> .js.
-# But this would cause Bazel outputs to collide with inputs so it requires some re-rooting scheme.
-# TODO: add this if users need it
-_SUPPORTED_EXTENSIONS = [".ts", ".tsx", ".jsx", ".mjs", ".cjs"]
-
-def _is_supported_src(src):
-    for e in _SUPPORTED_EXTENSIONS:
-        if src.endswith(e):
-            return True
-    return False
-
-def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = None, source_maps = None, source_map_outputs = False, **kwargs):
+def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = None, source_maps = False, **kwargs):
     """Execute the swc compiler
 
     Args:
@@ -45,14 +34,15 @@ def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = Non
         output_dir: whether to produce a directory output rather than individual files
         args: additional arguments to pass to swc cli, see https://swc.rs/docs/usage/cli
         source_maps: If set, the --source-maps argument is passed to the swc cli with the value.
+          See https://swc.rs/docs/usage/cli#--source-maps--s
           True/False are automaticaly converted to "true"/"false" string values the cli expects.
-          If source_maps is "true" or "both" then source_map_outputs is automatically set to True.
-        source_map_outputs: if the rule is expected to produce a .js.map file output for each .js file output
         swcrc: label of a configuration file for swc, see https://swc.rs/docs/configuration/swcrc
         **kwargs: additional named parameters like tags or visibility
     """
     if srcs == None:
-        srcs = native.glob(["**/*" + e for e in _SUPPORTED_EXTENSIONS])
+        srcs = native.glob(["**/*" + e for e in _swc_lib.SUPPORTED_EXTENSIONS])
+    elif not types.is_list(srcs):
+        fail("srcs must be a list, not a " + type(srcs))
 
     # Convert source_maps True/False to "true"/"false" args value
     if source_maps == True:
@@ -60,24 +50,13 @@ def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = Non
     elif source_maps == False:
         source_maps = "false"
 
-    # Detect if we are expecting sourcemap outputs
-    if not source_map_outputs:
-        source_map_outputs = (source_maps == "true" or source_maps == "both")
-
-    # Add the source_maps arg
-    if source_maps:
-        args = args + ["--source-maps", source_maps]
-
     # Determine js & map outputs
     js_outs = []
     map_outs = []
 
     if not output_dir:
-        for f in srcs:
-            if _is_supported_src(f):
-                js_outs.append(paths.replace_extension(f, ".js"))
-                if source_map_outputs:
-                    map_outs.append(paths.replace_extension(f, ".js.map"))
+        js_outs = _swc_lib.calculate_js_outs(srcs)
+        map_outs = _swc_lib.calculate_map_outs(srcs, source_maps)
 
     swc_transpiler(
         name = name,
@@ -85,6 +64,7 @@ def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = Non
         js_outs = js_outs,
         map_outs = map_outs,
         output_dir = output_dir,
+        source_maps = source_maps,
         args = args,
         data = data,
         swcrc = swcrc,

--- a/swc/tests/versions_test.bzl
+++ b/swc/tests/versions_test.bzl
@@ -7,7 +7,7 @@ load("//swc/private:versions.bzl", "TOOL_VERSIONS")
 
 def _smoke_test_impl(ctx):
     env = unittest.begin(ctx)
-    asserts.equals(env, "v1.2.119", TOOL_VERSIONS.keys()[0])
+    asserts.equals(env, "v1.2.141", TOOL_VERSIONS.keys()[0])
     return unittest.end(env)
 
 # The unittest library requires that we export the test cases as named test rules,


### PR DESCRIPTION
For example, filegroup can now be used to yield the sources we pass to swc.
Like with ts_project, this means we don't pre-declare outputs, since Bazel doesn't support that.