### PR TITLE
Rename main.js to main.cjs

### DIFF
--- a/swc/BUILD.bazel
+++ b/swc/BUILD.bazel
@@ -28,7 +28,7 @@ bzl_library(
 # Workaround: nodejs_binary doesn't support entry points under external yet
 write_file(
     name = "gen_main",
-    out = "main.js",
+    out = "main.cjs",
     content = ["require('@swc/cli')"],
 )
 
@@ -42,7 +42,7 @@ nodejs_binary(
         "@npm__swc_cli-0.1.52//:pkg",
         "@npm__swc_core-1.2.119//:pkg",
     ],
-    entry_point = "main.js",
+    entry_point = "main.cjs",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
When a user's root-level `package.json` includes `"type": "module"`, building with `rules_swc` produces the following error:

```
require('@swc/cli')
^

ReferenceError: require is not defined in ES module scope, you can use import instead
```

Renaming the `main.js` file to `main.cjs` resolves this issue.

_See minimal reproduction of the issue: https://github.com/Nick-Mazuk/bazel-swc-es6_