### PR TITLE
chore: remove maybe()

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -4,13 +4,15 @@ Users should *not* need to install these. If users see a load()
 statement from these, that's a bug in our distribution.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(name, **kwargs):
+    maybe(_http_archive, name = name, **kwargs)
 
 def rules_swc_internal_deps():
     "Fetch deps needed for local development"
-    maybe(
-        http_archive,
+    http_archive(
         name = "build_bazel_integration_testing",
         urls = [
             "https://github.com/bazelbuild/bazel-integration-testing/archive/165440b2dbda885f8d1ccb8d0f417e6cf8c54f17.zip",
@@ -19,8 +21,7 @@ def rules_swc_internal_deps():
         sha256 = "2401b1369ef44cc42f91dc94443ef491208dbd06da1e1e10b702d8c189f098e3",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
         urls = [
@@ -29,8 +30,7 @@ def rules_swc_internal_deps():
         ],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_gazelle",
         sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
         urls = [
@@ -42,8 +42,7 @@ def rules_swc_internal_deps():
     # Override bazel_skylib distribution to fetch sources instead
     # so that the gazelle extension is included
     # see https://github.com/bazelbuild/bazel-skylib/issues/250
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_skylib",
         sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
         strip_prefix = "bazel-skylib-1.1.1",
@@ -53,8 +52,7 @@ def rules_swc_internal_deps():
         ],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "io_bazel_stardoc",
         sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
         urls = [

--- a/swc/dependencies.bzl
+++ b/swc/dependencies.bzl
@@ -3,8 +3,11 @@
 Should be replaced by bzlmod for users of Bazel 6.0 and above.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(name, **kwargs):
+    maybe(_http_archive, name = name, **kwargs)
 
 # WARNING: any changes in this function may be BREAKING CHANGES for users
 # because we'll fetch a dependency which may be different from one that
@@ -13,8 +16,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 # changes in this function should be marked as BREAKING in the commit message
 # and released only in semver majors.
 def rules_swc_dependencies():
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_skylib",
         urls = [
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
@@ -23,23 +25,20 @@ def rules_swc_dependencies():
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "rules_nodejs",
         sha256 = "8f4a19de1eb16b57ac03a8e9b78344b44473e0e06b0510cec14a81f6adfdfc25",
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.6/rules_nodejs-core-4.4.6.tar.gz"],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "aspect_bazel_lib",
         sha256 = "8860aab705fe9f427fbebe388bdfacf8a6b267cb3c0d71ebeaf1dcceedd29193",
         strip_prefix = "bazel-lib-1.3.0",
         url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.3.0.tar.gz",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "aspect_rules_js",
         sha256 = "1fe40fd2819745ad19b5bec8f97a82087145fc6f145d3c84b0147899bf3490ca",
         strip_prefix = "rules_js-0.13.0",


### PR DESCRIPTION
This lets renovate understand our Bazel dependencies.
Note, this will soon be unneeded when https://github.com/renovatebot/renovate/pull/16003 lands and is released.

In the meantime we are near launch and want to keep our stuff updated.