### PR TITLE
chore: update to aspect_rules_js to latest commit hash

### DIFF
--- a/swc/dependencies.bzl
+++ b/swc/dependencies.bzl
@@ -34,9 +34,9 @@ def rules_swc_dependencies():
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "be39996444ab94de605e21cdcaa9bc4965a96186329d776e400b47fefd540902",
-        strip_prefix = "rules_js-1.0.0-rc.0",
-        url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.0.0-rc.0.tar.gz",
+        sha256 = "30cdb80469c54036617598d3845250cc8ff56bc5dd926bebd8d6a74d8f336f6f",
+        strip_prefix = "rules_js-87896ebaf575eca359293afbfa695464add256b2",
+        url = "https://github.com/aspect-build/rules_js/archive/87896ebaf575eca359293afbfa695464add256b2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
1.0.0-rc.2 breaks since we need the fix in https://github.com/aspect-build/rules_js/pull/323