### PR TITLE
fix: update transitive `@swc/cli` dependencies

### DIFF
--- a/swc/cli_repositories.bzl
+++ b/swc/cli_repositories.bzl
@@ -78,14 +78,14 @@ def npm_repositories():
             "commander": "7.2.0",
             "fast-glob": "3.2.11",
             "slash": "3.0.0",
-            "source-map": "0.7.3",
+            "source-map": "0.7.4",
         },
         transitive_closure = {
             "@swc/cli": ["0.1.57"],
             "commander": ["7.2.0"],
             "fast-glob": ["3.2.11"],
             "slash": ["3.0.0"],
-            "source-map": ["0.7.3"],
+            "source-map": ["0.7.4"],
             "@nodelib/fs.stat": ["2.0.5"],
             "@nodelib/fs.walk": ["1.2.8"],
             "glob-parent": ["5.1.2"],
@@ -242,7 +242,7 @@ def npm_repositories():
         package = "is-extglob",
         version = "2.1.1",
         lifecycle_hooks_no_sandbox = True,
-        integrity = "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+        integrity = "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
         transitive_closure = {
             "is-extglob": ["2.1.1"],
         },
@@ -392,16 +392,16 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "swc_cli__source-map__0.7.3",
+        name = "swc_cli__source-map__0.7.4",
         root_package = "swc",
         link_workspace = "aspect_rules_swc",
         link_packages = {},
         package = "source-map",
-        version = "0.7.3",
+        version = "0.7.4",
         lifecycle_hooks_no_sandbox = True,
-        integrity = "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+        integrity = "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
         transitive_closure = {
-            "source-map": ["0.7.3"],
+            "source-map": ["0.7.4"],
         },
     )
 

--- a/swc/pnpm-lock.yaml
+++ b/swc/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   "@swc/cli": latest
@@ -54,7 +54,7 @@ packages:
       commander: 7.2.0
       fast-glob: 3.2.11
       slash: 3.0.0
-      source-map: 0.7.3
+      source-map: 0.7.4
     dev: false
 
   /braces/3.0.2:
@@ -119,7 +119,10 @@ packages:
     dev: false
 
   /is-extglob/2.1.1:
-    resolution: { integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= }
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
     engines: { node: ">=0.10.0" }
     dev: false
 
@@ -200,10 +203,10 @@ packages:
     engines: { node: ">=8" }
     dev: false
 
-  /source-map/0.7.3:
+  /source-map/0.7.4:
     resolution:
       {
-        integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==,
+        integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==,
       }
     engines: { node: ">= 8" }
     dev: false


### PR DESCRIPTION
I was running into an issue with source maps and found it was identical to https://github.com/sveltejs/svelte/issues/7728.  The fix over there was updating `source-map` (since `source-map@0.7.3` checks for the environment by the existence of `fetch`, which is now included in Node, and `source-map@0.7.4` replaces this with a `window` check).  Since `source-map` is a transitive dependency of `@swc/cli`, it's part of the `pnpm-lock.yaml` included, but it's currently locked to `source-map@0.7.3`.  So, this PR was just the result of updating that, which fixes the source map issue.