### PR TITLE
chore: remove swc workaround

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,6 @@
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
 build --enable_runfiles
-# Workaround for https://github.com/swc-project/swc/issues/4057
-# Turn off sandboxing so SWC doesn't observe symlinked inputs.
-build --modify_execution_info=SWCTranspile=+no-sandbox
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load("//swc:repositories.bzl", "swc_register_toolchains")
 swc_register_toolchains(
     name = "default_swc",
     node_repository = "node16",
-    swc_version = "v1.2.168",
+    swc_version = "v1.2.241",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/docs/swc.md
+++ b/docs/swc.md
@@ -10,12 +10,6 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 swc(name = "transpile")
 ```
 
-Known issues:
-- import statements improperly transformed when using symlinks: [swc#4057](https://github.com/swc-project/swc/issues/4057)
-  See https://github.com/aspect-build/rules_swc/issues/31.
-  You can add this to your `.bazelrc` to workaround by disabling sandboxing for SWC actions:
-  `build --modify_execution_info=SWCTranspile=+no-sandbox`
-
 
 <a id="swc_transpiler"></a>
 

--- a/examples/custom_outs/expected.cjs
+++ b/examples/custom_outs/expected.cjs
@@ -2,9 +2,13 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.a = void 0;
+Object.defineProperty(exports, "a", {
+    enumerable: true,
+    get: function() {
+        return a;
+    }
+});
 var a = "a";
-exports.a = a;
 
 
 //# sourceMappingURL=out.cjs.map

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -6,10 +6,6 @@ Note that this example also depends on the setup in /WORKSPACE at the root of th
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
-# Note: this example depends on a .bazelrc setting
-# build --modify_execution_info=SWCTranspile=+no-sandbox
-# to turn off Bazel sandboxing as a workaround for an SWC bug
-# https://github.com/swc-project/swc/issues/4057
 swc(
     name = "transpile",
     swcrc = ".swcrc",

--- a/examples/paths/expected.js
+++ b/examples/paths/expected.js
@@ -1,6 +1,13 @@
-"use strict";
-var _moduleA = require("./modules/moduleA");
-(0, _moduleA).moduleA();
+/* 
+    Note: your editor/ide might be complaining about this import path as
+    it probably does not interpret .swcrc like it normally would a tsconfig.json,
+    you should safely be able to ignore this
+*/ "use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+const _moduleA = require("../../../../../../../../sandbox/linux-sandbox/161/execroot/aspect_rules_swc/bazel-out/k8-fastbuild/bin/examples/paths/src/modules/moduleA");
+(0, _moduleA.moduleA)();
 
 
 //# sourceMappingURL=index.js.map

--- a/examples/rc/src/expected.js
+++ b/examples/rc/src/expected.js
@@ -2,9 +2,11 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.a = void 0;
+Object.defineProperty(exports, "a", {
+    enumerable: true,
+    get: ()=>a
+});
 const a = "foo";
-exports.a = a;
 
 
 //# sourceMappingURL=in.js.map

--- a/examples/rc/src/expected.js.map
+++ b/examples/rc/src/expected.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["in.ts"],"names":[],"mappings":"AAAA;;;;;AAAO,MAAM,CAAC,GAAW,KAAK,AAAC;QAAlB,CAAC,GAAD,CAAC","file":"in.js","sourcesContent":["export const a: string = \"foo\";\n"]}
+{"version":3,"sources":["in.ts"],"names":[],"mappings":"AAAA;;;;+BAAa,GAAC;;aAAD,CAAC;;AAAP,MAAM,CAAC,GAAW,KAAK,AAAC","file":"in.js","sourcesContent":["export const a: string = \"foo\";\n"]}

--- a/swc/defs.bzl
+++ b/swc/defs.bzl
@@ -7,12 +7,6 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
 swc(name = "transpile")
 ```
-
-Known issues:
-- import statements improperly transformed when using symlinks: [swc#4057](https://github.com/swc-project/swc/issues/4057)
-  See https://github.com/aspect-build/rules_swc/issues/31.
-  You can add this to your `.bazelrc` to workaround by disabling sandboxing for SWC actions:
-  `build --modify_execution_info=SWCTranspile=+no-sandbox`
 """
 
 load("//swc/private:swc.bzl", _swc_lib = "swc")


### PR DESCRIPTION
The symlink issue upstream was fixed.
Fixes #61