### PR TITLE
Revert "feat: transpiler function returns unused srcs"

### DIFF
--- a/docs/swc.md
+++ b/docs/swc.md
@@ -81,8 +81,4 @@ Execute the swc compiler
 | <a id="swc-out_dir"></a>out_dir |  base directory for output files relative to the output directory for this package   |  <code>None</code> |
 | <a id="swc-kwargs"></a>kwargs |  additional named parameters like tags or visibility   |  none |
 
-**RETURNS**
-
-subset of srcs which aren't transpiled by swc
-
 

--- a/swc/defs.bzl
+++ b/swc/defs.bzl
@@ -50,9 +50,6 @@ def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = Non
         swcrc: label of a configuration file for swc, see https://swc.rs/docs/configuration/swcrc
         out_dir: base directory for output files relative to the output directory for this package
         **kwargs: additional named parameters like tags or visibility
-
-    Returns:
-        subset of srcs which aren't transpiled by swc
     """
     if srcs == None:
         srcs = native.glob(["**/*.ts", "**/*.tsx"])
@@ -86,7 +83,3 @@ def swc(name, srcs = None, args = [], data = [], output_dir = False, swcrc = Non
         out_dir = out_dir,
         **kwargs
     )
-
-    # Newer rules_ts versions make use of this return value.
-    # See https://github.com/aspect-build/rules_ts/blob/08f14d4ff792ca6fe091a009557642f7b0e20994/docs/transpiler.md#ts_projecttranspiler
-    return _swc_lib.calculate_unused_inputs(srcs)

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -100,9 +100,6 @@ def _calculate_map_out(src, source_maps, out_dir = None):
 def _calculate_map_outs(srcs, source_maps, out_dir = None):
     return [f2 for f2 in [_calculate_map_out(f, source_maps, out_dir) for f in srcs] if f2]
 
-def _calculate_unused_inputs(srcs):
-    return [s for s in srcs if not _is_supported_src(s)]
-
 def _impl(ctx):
     swcinfo = ctx.toolchains["@aspect_rules_swc//swc:toolchain_type"].swcinfo
     env = {
@@ -241,5 +238,4 @@ swc = struct(
     calculate_js_out = _calculate_js_out,
     calculate_js_outs = _calculate_js_outs,
     calculate_map_outs = _calculate_map_outs,
-    calculate_unused_inputs = _calculate_unused_inputs,
 )


### PR DESCRIPTION
Reverts aspect-build/rules_swc#116

Design wasn't thorough and there's a critical flaw with filegroups in srcs, we can't really predict this way.