### PR TITLE
Fix package-relative paths for external sources

### DIFF
--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -58,7 +58,14 @@ def _is_supported_src(src):
 
 # TODO: aspect_bazel_lib should provide this?
 def _relative_to_package(path, ctx):
-    for prefix in (ctx.bin_dir.path, ctx.label.package):
+    package_path = ctx.label.package
+    if ctx.label.workspace_root:
+        # If the target label is external (like "@REPO_NAME//some/target")
+        # then it will be placed under "external/REPO_NAME/some/target",
+        # rather than just "some/target", so take that into account here.
+        package_path = ctx.label.workspace_root + "/" + package_path
+
+    for prefix in (ctx.bin_dir.path, package_path):
         prefix += "/"
         if path.startswith(prefix):
             path = path[len(prefix):]


### PR DESCRIPTION
Context: this unblocks migration of BuildBuddy to `rules_js`. We build our app externally like `bazel build @com_github_buildbuddy_io_buildbuddy//enterprise/app:app_bundle` when deploying via our internal repo, and this is broken because the current logic in rules_swc results in files being written to the wrong path.

Before, we'd get an error from esbuild like `app.tsx: ERROR: Could not resolve "./root/root"`, and inspecting the sandbox dir after building with `--sandbox_debug`, the tree would look like this (filtering just to `app.tsx` and `root.js` here which are the main relevant files):

```
$(bazel-sandbox)/buildbuddy_internal/
    - bazel-out/k8-opt/bin/
        - external/com_github_buildbuddy_io_buildbuddy/
            - enterprise/app/
                - app.tsx  # esbuild entrypoint
                - external/com_github_buildbuddy_io_buildbuddy/enterprise/app/root/
                    - root.js # generated by SWC
```

The problem is that `esbuild` can't locate `./root/root.js` because it's nested under `./external/com_github_buildbuddy_io_buildbuddy/enterprise/app/root/` relative to `app.tsx`, when it should just be under `./root/root`.

This PR fixes that issue. After the fix, the directory structure looks like this:

```
$(bazel-sandbox)/buildbuddy_internal/
    - bazel-out/k8-opt/bin/
        - external/com_github_buildbuddy_io_buildbuddy/
            - enterprise/app/
                - app.tsx
                - root/
                    - root.js
```