### PR TITLE
chore: cleanup paths example

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,9 +26,11 @@ swc_register_toolchains(
     swc_version = "v1.3.25",
 )
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_jq_toolchains")
 
 aspect_bazel_lib_dependencies(override_local_config_platform = True)
+
+register_jq_toolchains()
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 

--- a/examples/custom_outs/BUILD.bazel
+++ b/examples/custom_outs/BUILD.bazel
@@ -7,7 +7,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 # Note, --config is documented on swcx CLI but isn't functional. See
 # https://github.com/swc-project/swc/issues/4017#issuecomment-1374141572
 # In the call to swc_compile below, we ought to be able to use
-#   `args = ["--config", "module.format=" + format]`
+#   `args = ["--config", "module.type=" + format]`
 # As a workaround, write our config to an rc file. Can be changed back when swcx supports --config.
 [
     write_file(

--- a/examples/paths/.swcrc
+++ b/examples/paths/.swcrc
@@ -6,7 +6,7 @@
     "target": "es2021",
     "baseUrl": "examples/paths",
     "paths": {
-      "@modules/*": ["src/modules/*"]
+      "@modules/*": ["./src/modules/*"]
     }
   },
   "module": {

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -6,9 +6,17 @@ Note that this example also depends on the setup in /WORKSPACE at the root of th
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_swc//swc/private:testing.bzl", "matching_paths_test")
+
 swc(
     name = "compile",
     swcrc = ".swcrc",
+)
+
+# Verify that the "paths" entry is agreed between swc and TS language service (in the editor)
+matching_paths_test(
+    name = "check_paths",
 )
 
 write_source_files(

--- a/examples/paths/expected.js
+++ b/examples/paths/expected.js
@@ -1,10 +1,6 @@
-/* 
-    Note: your editor/ide might be complaining about this import path as
-    it probably does not interpret .swcrc like it normally would a tsconfig.json,
-    you should safely be able to ignore this
-*/ "use strict";
+"use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _moduleX = require("./modules/moduleX");
-(0, _moduleX.moduleA)(); //# sourceMappingURL=index.js.map
+const _moduleA = require("./modules/moduleA");
+(0, _moduleA.moduleA)(); //# sourceMappingURL=index.js.map

--- a/examples/paths/src/index.ts
+++ b/examples/paths/src/index.ts
@@ -1,9 +1,4 @@
-/* 
-    Note: your editor/ide might be complaining about this import path as
-    it probably does not interpret .swcrc like it normally would a tsconfig.json,
-    you should safely be able to ignore this
-*/
-import { moduleA } from "@modules/moduleX";
+import { moduleA } from "@modules/moduleA";
 
 moduleA();
 

--- a/examples/paths/src/modules/moduleA/index.ts
+++ b/examples/paths/src/modules/moduleA/index.ts
@@ -1,8 +1,3 @@
-/* 
-    Note: your editor/ide might be complaining about this import path as
-    it probably does not interpret .swcrc like it normally would a tsconfig.json,
-    you should safely be able to ignore this
-*/
 import { moduleB } from "@modules/moduleB";
 
 export const moduleA = () => {

--- a/examples/paths/tsconfig.json
+++ b/examples/paths/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@modules/*": ["./src/modules/*"]
+    }
+  }
+}

--- a/swc/private/testing.bzl
+++ b/swc/private/testing.bzl
@@ -1,0 +1,27 @@
+"""Utilities for writing tests
+
+TODO: promote to public API.
+"""
+
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+def matching_paths_test(name, tsconfig = "tsconfig.json", swcrc = ".swcrc"):
+    jq(
+        name = "_ts_" + name,
+        srcs = [tsconfig],
+        filter = ".compilerOptions.paths",
+    )
+
+    jq(
+        name = "_swc_" + name,
+        srcs = [swcrc],
+        filter = ".jsc.paths",
+    )
+
+    diff_test(
+        name = name,
+        file1 = "_ts_" + name,
+        file2 = "_swc_" + name,
+        failure_message = "tsconfig compilerOptions.paths don't match swcrc jsc.paths",
+    )


### PR DESCRIPTION
We shouldn't have an example that's red in the editor, that's just confusing users with a bad pattern