### PR TITLE
feat: read swc version from package.json

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ swc_register_toolchains(
         "linux-arm64-gnu": "sha384-2uYEohzUAAalEGiD0iEPEDWlR1BCM4q+DhsnIe5saa8B2+igdLzsQrbREimhu5TJ",
         "linux-x64-gnu": "sha384-c46sYs/jCA4OjV7LeWT201dYQDTO76V6sZzdtOiGt+3Gls9n6QG+K4hkpIE+wy0k",
     },
-    swc_version = "v1.3.25",
+    swc_version_from = "//:package.json",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "// this file only used for WORKSPACE to infer our version of swc": "",
+  "devDependencies": {
+    "@swc/core": "1.3.25"
+  }
+}


### PR DESCRIPTION
This makes it easier for users to ensure that Bazel and non-bazel tooling don't have skewed tool versions

BREAKING CHANGE:
An explicit version now has to be given to swc_register_toolchains, we don't silently default to latest

Fixes #120