### PR TITLE
Add support for plugins

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,10 +18,10 @@ swc_register_toolchains(
     name = "swc",
     # Demonstrates how users can choose ANY swc version, not just the ones we mirrored
     integrity_hashes = {
-        "darwin-arm64": "sha384-tSMDc6MG2llNW0PoEaWayHSia7YXDWVV+ceaiAl3Ew1xGA3lmfC2wTuKzaJU+16o",
-        "darwin-x64": "sha384-e9/dVt6KQTPVyH3y2Oy8J+Bz5XVI0hiK6fwknNsq/yTY+hftJ+SDqDW2YMkfCa3C",
-        "linux-arm64-gnu": "sha384-cipAIuV6Sa33feJMftOL56t3yEqr0/E6feFWkBnbIAtlSFsUEcv7LY+M7zLdn7Or",
-        "linux-x64-gnu": "sha384-s9hTnWi9jZM2MZJNnCn7Pg19vfSLnf8kCCYAgBN4UM4NFlN8+BpfGHG+jzq6BkaA",
+        "darwin-arm64": "sha384-87HERB0qZ2UqjSxLMpQB7EtYASe7ovT36pPtj409p6eDtM9dAEEXQS10nJ/OOz3O",
+        "darwin-x64": "sha384-i3poY6tNdi83tkpaV+uDgTR1jYxHIXzeqS1KAi8+DZKHUvwlyEXmwDWly0kZPWDs",
+        "linux-arm64-gnu": "sha384-2Q5viIs4jkFd/H0abMrUhZP/ILfY3S3GceoU9vBfRfJgCj+GF9SARoCQa7cRYEBb",
+        "linux-x64-gnu": "sha384-k5POzu1Ub30FlqagD+Voq5vE/pwB6SB4WD2SH5Yg/ALdC7pligR0avdRyFjVZ2oS",
     },
     swc_version_from = "//:package.json",
 )

--- a/docs/swc.md
+++ b/docs/swc.md
@@ -18,8 +18,8 @@ swc(name = "compile")
 ## swc_compile
 
 <pre>
-swc_compile(<a href="#swc_compile-name">name</a>, <a href="#swc_compile-args">args</a>, <a href="#swc_compile-data">data</a>, <a href="#swc_compile-js_outs">js_outs</a>, <a href="#swc_compile-map_outs">map_outs</a>, <a href="#swc_compile-out_dir">out_dir</a>, <a href="#swc_compile-output_dir">output_dir</a>, <a href="#swc_compile-root_dir">root_dir</a>, <a href="#swc_compile-source_maps">source_maps</a>, <a href="#swc_compile-srcs">srcs</a>,
-            <a href="#swc_compile-swcrc">swcrc</a>)
+swc_compile(<a href="#swc_compile-name">name</a>, <a href="#swc_compile-args">args</a>, <a href="#swc_compile-data">data</a>, <a href="#swc_compile-js_outs">js_outs</a>, <a href="#swc_compile-map_outs">map_outs</a>, <a href="#swc_compile-out_dir">out_dir</a>, <a href="#swc_compile-output_dir">output_dir</a>, <a href="#swc_compile-plugins">plugins</a>, <a href="#swc_compile-root_dir">root_dir</a>,
+            <a href="#swc_compile-source_maps">source_maps</a>, <a href="#swc_compile-srcs">srcs</a>, <a href="#swc_compile-swcrc">swcrc</a>)
 </pre>
 
 Underlying rule for the `swc` macro.
@@ -43,6 +43,7 @@ for example to set your own output labels for `js_outs`.
 | <a id="swc_compile-map_outs"></a>map_outs |  list of expected source map output files.<br><br>Can be empty, meaning no source maps should be produced. If non-empty, there should be one for each entry in srcs.   | List of labels | optional |  |
 | <a id="swc_compile-out_dir"></a>out_dir |  base directory for output files   | String | optional | <code>""</code> |
 | <a id="swc_compile-output_dir"></a>output_dir |  whether to produce a directory output rather than individual files   | Boolean | optional | <code>False</code> |
+| <a id="swc_compile-plugins"></a>plugins |  swc compilation plugins, created with swc_plugin rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="swc_compile-root_dir"></a>root_dir |  a subdirectory under the input package which should be consider the root directory of all the input files   | String | optional | <code>""</code> |
 | <a id="swc_compile-source_maps"></a>source_maps |  see https://swc.rs/docs/usage/cli#--source-maps--s   | String | optional | <code>"false"</code> |
 | <a id="swc_compile-srcs"></a>srcs |  source files, typically .ts files in the source tree   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
@@ -54,7 +55,7 @@ for example to set your own output labels for `js_outs`.
 ## swc
 
 <pre>
-swc(<a href="#swc-name">name</a>, <a href="#swc-srcs">srcs</a>, <a href="#swc-args">args</a>, <a href="#swc-data">data</a>, <a href="#swc-output_dir">output_dir</a>, <a href="#swc-swcrc">swcrc</a>, <a href="#swc-source_maps">source_maps</a>, <a href="#swc-out_dir">out_dir</a>, <a href="#swc-root_dir">root_dir</a>, <a href="#swc-kwargs">kwargs</a>)
+swc(<a href="#swc-name">name</a>, <a href="#swc-srcs">srcs</a>, <a href="#swc-args">args</a>, <a href="#swc-data">data</a>, <a href="#swc-plugins">plugins</a>, <a href="#swc-output_dir">output_dir</a>, <a href="#swc-swcrc">swcrc</a>, <a href="#swc-source_maps">source_maps</a>, <a href="#swc-out_dir">out_dir</a>, <a href="#swc-root_dir">root_dir</a>, <a href="#swc-kwargs">kwargs</a>)
 </pre>
 
 Execute the SWC compiler
@@ -68,11 +69,33 @@ Execute the SWC compiler
 | <a id="swc-srcs"></a>srcs |  List of labels of TypeScript source files.   |  <code>None</code> |
 | <a id="swc-args"></a>args |  Additional options to pass to <code>swcx</code> cli, see https://github.com/swc-project/swc/discussions/3859 Note: we do **not** run the [NodeJS wrapper <code>@swc/cli</code>](https://swc.rs/docs/usage/cli)   |  <code>[]</code> |
 | <a id="swc-data"></a>data |  Files needed at runtime by binaries or tests that transitively depend on this target. See https://bazel.build/reference/be/common-definitions#typical-attributes   |  <code>[]</code> |
+| <a id="swc-plugins"></a>plugins |  List of plugin labels created with <code>swc_plugin</code>.   |  <code>[]</code> |
 | <a id="swc-output_dir"></a>output_dir |  Whether to produce a directory output rather than individual files   |  <code>False</code> |
 | <a id="swc-swcrc"></a>swcrc |  Label of a .swcrc configuration file for the SWC cli, see https://swc.rs/docs/configuration/swcrc Instead of a label, you can pass a dictionary matching the JSON schema. If this attribute isn't specified, and a file <code>.swcrc</code> exists in the same folder as this rule, it is used.<br><br>Note that some settings in <code>.swcrc</code> also appear in <code>tsconfig.json</code>. See the notes in [/docs/tsconfig.md].   |  <code>None</code> |
 | <a id="swc-source_maps"></a>source_maps |  If set, the --source-maps argument is passed to the SWC cli with the value. See https://swc.rs/docs/usage/cli#--source-maps--s. True/False are automaticaly converted to "true"/"false" string values the cli expects.   |  <code>False</code> |
 | <a id="swc-out_dir"></a>out_dir |  The base directory for output files relative to the output directory for this package   |  <code>None</code> |
 | <a id="swc-root_dir"></a>root_dir |  A subdirectory under the input package which should be considered the root directory of all the input files   |  <code>None</code> |
 | <a id="swc-kwargs"></a>kwargs |  additional keyword arguments passed through to underlying [<code>swc_compile</code>](#swc_compile), eg. <code>visibility</code>, <code>tags</code>   |  none |
+
+
+<a id="swc_plugin"></a>
+
+## swc_plugin
+
+<pre>
+swc_plugin(<a href="#swc_plugin-name">name</a>, <a href="#swc_plugin-src">src</a>, <a href="#swc_plugin-config">config</a>, <a href="#swc_plugin-kwargs">kwargs</a>)
+</pre>
+
+Configure an SWC plugin
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swc_plugin-name"></a>name |  A name for this target   |  none |
+| <a id="swc_plugin-src"></a>src |  Label for the plugin, either a directory containing a package.json pointing at a wasm file as the main entrypoint, or a wasm file. Usually a linked npm package target via rules_js.   |  <code>None</code> |
+| <a id="swc_plugin-config"></a>config |  Optional configuration dict for the plugin. This is passed as a JSON object into the <code>jsc.experimental.plugins</code> entry for the plugin.   |  <code>{}</code> |
+| <a id="swc_plugin-kwargs"></a>kwargs |  additional keyword arguments passed through to underlying rule, eg. <code>visibility</code>, <code>tags</code>   |  none |
 
 

--- a/examples/plugins/BUILD.bazel
+++ b/examples/plugins/BUILD.bazel
@@ -1,0 +1,86 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_rules_swc//swc:defs.bzl", "swc", "swc_plugin")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+directory_path(
+    name = "plugin_wasm_path",
+    directory = ":node_modules/@swc/plugin-transform-imports/dir",
+    path = "swc_plugin_transform_imports.wasm",
+)
+
+copy_file(
+    name = "plugin_wasm",
+    src = ":plugin_wasm_path",
+    out = "plugin.wasm",
+)
+
+# plugin from an npm package, this will work if the package.json
+# includes a main entrypoint pointing at the plugin wasm file.
+swc_plugin(
+    name = "npm_plugin",
+    src = ":node_modules/@swc/plugin-transform-imports",
+    # optional plugin config, the JSON object for the plugin passed into jsc.experimental.plugins
+    # https://swc.rs/docs/configuration/compilation#jscexperimentalplugins
+    config = {
+        "lodash": {
+            "transform": "lodash/{{member}}",
+        },
+    },
+)
+
+# plugin referencing a wasm file directly,
+# for example a rust_binary target set up to build wasm
+swc_plugin(
+    name = "file_plugin",
+    src = ":plugin_wasm",
+    config = {
+        "lodash2": {
+            "transform": "lodash/test/{{member}}",
+        },
+    },
+)
+
+swc(
+    name = "simple",
+    out_dir = "simple",
+    plugins = [
+        ":npm_plugin",
+    ],
+)
+
+swc(
+    name = "rcdict",
+    out_dir = "rcdict",
+    plugins = [
+        ":npm_plugin",
+        ":file_plugin",
+    ],
+    swcrc = {
+        "jsc": {
+            "target": "es2015",
+        },
+    },
+)
+
+swc(
+    name = "rc",
+    out_dir = "rc",
+    plugins = [
+        ":npm_plugin",
+        ":file_plugin",
+    ],
+    swcrc = "minify.swcrc",
+)
+
+write_source_files(
+    name = "test",
+    files = {
+        "expected_simple.js_": ":simple/in.js",
+        "expected_rc.js_": ":rc/in.js",
+        "expected_rcdict.js_": ":rcdict/in.js",
+    },
+)

--- a/examples/plugins/expected_rc.js_
+++ b/examples/plugins/expected_rc.js_
@@ -1,0 +1,1 @@
+import map from"lodash/map";import sort from"lodash/test/sort";var foo="bar";var _m=map;var _s=sort;

--- a/examples/plugins/expected_rcdict.js_
+++ b/examples/plugins/expected_rcdict.js_
@@ -1,0 +1,5 @@
+import map from "lodash/map";
+import sort from "lodash/test/sort";
+const foo = "bar";
+let _m = map;
+let _s = sort;

--- a/examples/plugins/expected_simple.js_
+++ b/examples/plugins/expected_simple.js_
@@ -1,0 +1,5 @@
+import map from "lodash/map";
+import { sort } from "lodash2";
+var foo = "bar";
+var _m = map;
+var _s = sort;

--- a/examples/plugins/in.ts
+++ b/examples/plugins/in.ts
@@ -1,0 +1,6 @@
+import { map } from "lodash";
+import { sort } from "lodash2";
+
+const foo = "bar";
+let _m = map;
+let _s = sort;

--- a/examples/plugins/minify.swcrc
+++ b/examples/plugins/minify.swcrc
@@ -1,0 +1,3 @@
+{
+    "minify": true
+}

--- a/examples/plugins/package.json
+++ b/examples/plugins/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@swc/plugin-transform-imports": "1.5.41"
+  }
+}

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -1,59 +1,63 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
+  .:
+    specifiers: {}
+
   generate_swcrc:
     specifiers:
       tsconfig-to-swcconfig: ~2.0.1
     devDependencies:
-      tsconfig-to-swcconfig: registry.npmjs.org/tsconfig-to-swcconfig/2.0.1
+      tsconfig-to-swcconfig: 2.0.1
+
+  plugins:
+    specifiers:
+      "@swc/plugin-transform-imports": 1.5.41
+    devDependencies:
+      "@swc/plugin-transform-imports": 1.5.41
 
 packages:
-  registry.npmjs.org/deepmerge/4.2.2:
+  /@swc/plugin-transform-imports/1.5.41:
+    resolution:
+      {
+        integrity: sha512-sywDxWfKg3Jqm7s7X81uN9P6HbrX9oBYF8lHYzT6/1c/ovVG3RGG/1bDOQpzb+IC7C/h2oI2ESOKMKibbKsq1Q==,
+      }
+    dev: true
+
+  /deepmerge/4.2.2:
     resolution:
       {
         integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==,
         registry: https://registry.npmjs.com/,
-        tarball: https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz,
       }
-    name: deepmerge
-    version: 4.2.2
     engines: { node: ">=0.10.0" }
     dev: true
 
-  registry.npmjs.org/joycon/3.1.1:
+  /joycon/3.1.1:
     resolution:
       {
         integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
         registry: https://registry.npmjs.com/,
-        tarball: https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz,
       }
-    name: joycon
-    version: 3.1.1
     engines: { node: ">=10" }
     dev: true
 
-  registry.npmjs.org/jsonc-parser/3.2.0:
+  /jsonc-parser/3.2.0:
     resolution:
       {
         integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==,
         registry: https://registry.npmjs.com/,
-        tarball: https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz,
       }
-    name: jsonc-parser
-    version: 3.2.0
     dev: true
 
-  registry.npmjs.org/tsconfig-to-swcconfig/2.0.1:
+  /tsconfig-to-swcconfig/2.0.1:
     resolution:
       {
         integrity: sha512-GD4rQFgw2Vdi9D81eO7F0OfKZPiBPdyB5mwbUgnGqD3jWBT8dW9TDT9vLMkbyEYM+FSv09nqmbZpzAdRDni0WQ==,
         registry: https://registry.npmjs.com/,
-        tarball: https://registry.npmjs.org/tsconfig-to-swcconfig/-/tsconfig-to-swcconfig-2.0.1.tgz,
       }
-    name: tsconfig-to-swcconfig
-    version: 2.0.1
     dependencies:
-      deepmerge: registry.npmjs.org/deepmerge/4.2.2
-      joycon: registry.npmjs.org/joycon/3.1.1
-      jsonc-parser: registry.npmjs.org/jsonc-parser/3.2.0
+      deepmerge: 4.2.2
+      joycon: 3.1.1
+      jsonc-parser: 3.2.0
     dev: true

--- a/examples/pnpm-workspace.yaml
+++ b/examples/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - generate_swcrc
+  - plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "// this file only used for WORKSPACE to infer our version of swc": "",
   "devDependencies": {
-    "@swc/core": "1.3.31"
+    "@swc/core": "1.3.34"
   }
 }

--- a/swc/BUILD.bazel
+++ b/swc/BUILD.bazel
@@ -50,6 +50,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//swc/private:swc",
+        "//swc/private:swc_plugin",
         "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:write_file",
     ],
@@ -60,6 +61,12 @@ bzl_library(
     srcs = ["extensions.bzl"],
     visibility = ["//visibility:public"],
     deps = [":repositories"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/swc/private/BUILD.bazel
+++ b/swc/private/BUILD.bazel
@@ -1,21 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
-    name = "resolved_toolchain",
-    srcs = ["resolved_toolchain.bzl"],
+    name = "swc_plugin",
+    srcs = ["swc_plugin.bzl"],
     visibility = ["//swc:__subpackages__"],
-)
-
-bzl_library(
-    name = "toolchains_repo",
-    srcs = ["toolchains_repo.bzl"],
-    visibility = ["//swc:__subpackages__"],
-)
-
-bzl_library(
-    name = "versions",
-    srcs = ["versions.bzl"],
-    visibility = ["//swc:__subpackages__"],
+    deps = ["//swc:providers"],
 )
 
 bzl_library(

--- a/swc/private/BUILD.bazel
+++ b/swc/private/BUILD.bazel
@@ -39,3 +39,21 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
+
+bzl_library(
+    name = "resolved_toolchain",
+    srcs = ["resolved_toolchain.bzl"],
+    visibility = ["//swc:__subpackages__"],
+)
+
+bzl_library(
+    name = "toolchains_repo",
+    srcs = ["toolchains_repo.bzl"],
+    visibility = ["//swc:__subpackages__"],
+)
+
+bzl_library(
+    name = "versions",
+    srcs = ["versions.bzl"],
+    visibility = ["//swc:__subpackages__"],
+)

--- a/swc/private/swc_plugin.bzl
+++ b/swc/private/swc_plugin.bzl
@@ -1,0 +1,33 @@
+"Implementation details for swc_plugin rule"
+
+load("//swc:providers.bzl", "SwcPluginConfigInfo")
+
+_attrs = {
+    "src": attr.label(
+        doc = "label for the plugin, either a directory containing a package.json pointing at a wasm file as the main entrypoint, or a wasm file",
+        providers = [DefaultInfo],
+        mandatory = True,
+        allow_files = True,
+    ),
+    "config": attr.string(
+        doc = "configuration object for the plugin, serialized JSON object",
+        default = "{}",
+    ),
+}
+
+def _impl(ctx):
+    return [
+        DefaultInfo(
+            files = ctx.attr.src[DefaultInfo].files,
+        ),
+        SwcPluginConfigInfo(
+            label = ctx.label,
+            config = ctx.attr.config,
+        ),
+    ]
+
+swc_plugin = struct(
+    attrs = _attrs,
+    implementation = _impl,
+    provides = [DefaultInfo, SwcPluginConfigInfo],
+)

--- a/swc/providers.bzl
+++ b/swc/providers.bzl
@@ -1,0 +1,9 @@
+"""Providers for building derivative rules"""
+
+SwcPluginConfigInfo = provider(
+    doc = "Provides a configuration for an SWC plugin",
+    fields = {
+        "label": "the label of the target that created this provider",
+        "config": "the plugin configuration string, encoded from a JSON object",
+    },
+)


### PR DESCRIPTION
This PR implements all of the wiring necessary to use SWC plugins.

- Add a `swc_plugin` macro/rule pair that creates a target with the necessary providers:
  - a `DefaultInfo` pointing at a wasm file or an npm package containing a wasm file as the `main` entrypoint in the `package.json`
  - a new `SwcPluginConfigInfo` holding the plugin configuration
- Add a `plugins` attr to `swc_compile` and `swc`, taking a list of plugin targets, along with helpers to inject the plugin config.