### PR TITLE
refactor: force users to explicitly provide srcs

### DIFF
--- a/docs/swc.md
+++ b/docs/swc.md
@@ -2,14 +2,15 @@
 
 API for running the SWC cli under Bazel
 
-The simplest usage is a single line.
-It relies on the `swcrc` attribute automatically discovering `.swcrc`
-and the `srcs` attribute default of `glob(["**/*.ts", "**/*.tsx"])`:
+The simplest usage relies on the `swcrc` attribute automatically discovering `.swcrc`:
 
 ```starlark
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
-swc(name = "compile")
+swc(
+    name = "compile",
+    srcs = ["file.ts"],
+)
 ```
 
 
@@ -66,7 +67,7 @@ Execute the SWC compiler
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="swc-name"></a>name |  A name for this target   |  none |
-| <a id="swc-srcs"></a>srcs |  List of labels of TypeScript source files.   |  <code>None</code> |
+| <a id="swc-srcs"></a>srcs |  List of labels of TypeScript source files.   |  none |
 | <a id="swc-args"></a>args |  Additional options to pass to <code>swcx</code> cli, see https://github.com/swc-project/swc/discussions/3859 Note: we do **not** run the [NodeJS wrapper <code>@swc/cli</code>](https://swc.rs/docs/usage/cli)   |  <code>[]</code> |
 | <a id="swc-data"></a>data |  Files needed at runtime by binaries or tests that transitively depend on this target. See https://bazel.build/reference/be/common-definitions#typical-attributes   |  <code>[]</code> |
 | <a id="swc-plugins"></a>plugins |  List of plugin labels created with <code>swc_plugin</code>.   |  <code>[]</code> |

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
-swc(name = "compile")
+swc(
+    name = "compile",
+    srcs = ["foo.ts"],
+)
 
 build_test(
     name = "test",

--- a/examples/generate_swcrc/BUILD.bazel
+++ b/examples/generate_swcrc/BUILD.bazel
@@ -32,6 +32,7 @@ js_run_binary(
 # Demonstrate that it works
 swc(
     name = "compile",
+    srcs = ["some.ts"],
     swcrc = ".swcrc",
 )
 

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -8,7 +8,10 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
 # Note: The .swcrc configuration file will be automatically used, if it is present in the current directory
-swc(name = "compile")
+swc(
+    name = "compile",
+    srcs = glob(["**/*.ts"]),
+)
 
 # Verify that the "paths" entry is agreed between swc and TS language service (in the editor)
 assert_json_matches(

--- a/examples/plugins/BUILD.bazel
+++ b/examples/plugins/BUILD.bazel
@@ -29,6 +29,7 @@ swc_plugin(
 # Now we just pass our swc_plugin target to the plugins attribute:
 swc(
     name = "simple",
+    srcs = ["in.ts"],
     out_dir = "simple",
     plugins = [":npm_plugin"],
 )
@@ -65,6 +66,7 @@ swc_plugin(
 # Illustrates that the plugins work with swcrc settings in BUILD.bazel.
 swc(
     name = "rcdict",
+    srcs = ["in.ts"],
     out_dir = "rcdict",
     plugins = [
         ":npm_plugin",
@@ -80,6 +82,7 @@ swc(
 # Illustrates that the plugins work when using a .swcrc file.
 swc(
     name = "rc",
+    srcs = ["in.ts"],
     out_dir = "rc",
     plugins = [
         ":npm_plugin",

--- a/examples/rc/src/BUILD.bazel
+++ b/examples/rc/src/BUILD.bazel
@@ -4,9 +4,9 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 # Runs `swc in.ts > ../../bazel-bin/examples/simple/in.js`
 # You can run `bazel build --subcommands //examples/simple:compile`
 # to see the exact command line Bazel runs.
-# Note that by default, sources are found by glob(["**/*.ts"])
 swc(
     name = "compile",
+    srcs = ["in.ts"],
     source_maps = True,
     swcrc = "//examples/rc:.swcrc",
 )

--- a/examples/rcdict/BUILD.bazel
+++ b/examples/rcdict/BUILD.bazel
@@ -5,6 +5,7 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
 swc(
     name = "es5",
+    srcs = ["in.ts"],
     out_dir = "es5",
     swcrc = {
         "jsc": {
@@ -15,6 +16,7 @@ swc(
 
 swc(
     name = "es2015",
+    srcs = ["in.ts"],
     out_dir = "es2015",
     swcrc = {
         "jsc": {

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -9,8 +9,10 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 # Runs `swc in.ts > ../../bazel-bin/examples/simple/in.js`
 # You can run `bazel build --subcommands //examples/simple:compile`
 # to see the exact command line Bazel runs.
-# Note that by default, sources are found by glob(["**/*.ts"])
-swc(name = "compile")
+swc(
+    name = "compile",
+    srcs = ["in.ts"],
+)
 
 # Assert that the output of "compile" rule matches the expected file.
 write_source_files(

--- a/swc/defs.bzl
+++ b/swc/defs.bzl
@@ -1,13 +1,14 @@
 """API for running the SWC cli under Bazel
 
-The simplest usage is a single line.
-It relies on the `swcrc` attribute automatically discovering `.swcrc`
-and the `srcs` attribute default of `glob(["**/*.ts", "**/*.tsx"])`:
+The simplest usage relies on the `swcrc` attribute automatically discovering `.swcrc`:
 
 ```starlark
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
-swc(name = "compile")
+swc(
+    name = "compile",
+    srcs = ["file.ts"],
+)
 ```
 """
 
@@ -31,7 +32,7 @@ for example to set your own output labels for `js_outs`.
     toolchains = _swc_lib.toolchains,
 )
 
-def swc(name, srcs = None, args = [], data = [], plugins = [], output_dir = False, swcrc = None, source_maps = False, out_dir = None, root_dir = None, **kwargs):
+def swc(name, srcs, args = [], data = [], plugins = [], output_dir = False, swcrc = None, source_maps = False, out_dir = None, root_dir = None, **kwargs):
     """Execute the SWC compiler
 
     Args:
@@ -66,9 +67,7 @@ def swc(name, srcs = None, args = [], data = [], plugins = [], output_dir = Fals
 
         **kwargs: additional keyword arguments passed through to underlying [`swc_compile`](#swc_compile), eg. `visibility`, `tags`
     """
-    if srcs == None:
-        srcs = native.glob(["**/*.ts", "**/*.tsx"])
-    elif not types.is_list(srcs):
+    if not types.is_list(srcs):
         fail("srcs must be a list, not a " + type(srcs))
 
     if swcrc == None:


### PR DESCRIPTION
BREAKING CHANGE

It's too magical for us to discover them with a glob, making it harder to read the BUILD file and know what's going on