### PR TITLE
refactor: only use underlying rule where required

### DIFF
--- a/examples/custom_outs/BUILD.bazel
+++ b/examples/custom_outs/BUILD.bazel
@@ -2,16 +2,16 @@
 
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_outputs")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_swc//swc:defs.bzl", "swc_compile")
+load("@aspect_rules_swc//swc:defs.bzl", "swc", "swc_compile")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 ###############################
 # Case 1: js extension variants
 # .mts -> .mjs
-swc_compile(
+swc(
     name = "esmodule",
     srcs = ["b.mts"],
-    source_maps = "true",
+    source_maps = True,
 )
 
 assert_outputs(
@@ -52,6 +52,8 @@ assert_outputs(
 ]
 
 [
+    # Here, we use the underlying rule rather than the macro, so that we can control what js output
+    # paths are pre-declared.
     swc_compile(
         name = "compile_" + format,
         srcs = ["a.ts"],

--- a/examples/filegroup/BUILD.bazel
+++ b/examples/filegroup/BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
 swc(
     name = "compile",
     srcs = ["srcs"],
-    source_maps = "true",
+    source_maps = True,
     # We don't have to specify this. When a .swcrc configuration file is present in the current directory, it's used automatically.
     # swcrc = ".swcrc",
 )

--- a/examples/out_dir/BUILD.bazel
+++ b/examples/out_dir/BUILD.bazel
@@ -8,7 +8,7 @@ swc(
         "b.ts",
     ],
     out_dir = "out",
-    source_maps = "true",
+    source_maps = True,
 )
 
 # Since the srcs were in a filegroup, the swc macro cannot pre-declare the outputs.

--- a/examples/root_dir/BUILD.bazel
+++ b/examples/root_dir/BUILD.bazel
@@ -9,7 +9,7 @@ swc(
     ],
     out_dir = "out",
     root_dir = "src",
-    source_maps = "true",
+    source_maps = True,
 )
 
 # Since the srcs were in a filegroup, the swc macro cannot pre-declare the outputs.


### PR DESCRIPTION
Also use boolean rather than string where possible.