### PR TITLE
release: publish release artifact

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_swc-{TAG}.tar.gz"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
-      - name: Prepare workspace snippet
-        run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+      - name: Prepare release
+        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -36,3 +36,5 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          files: rules_swc-*.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -5,9 +5,11 @@ set -o errexit -o nounset -o pipefail
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
-# Strip leading 'v'
+# The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_swc-${TAG:1}"
-SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+ARCHIVE="rules_swc-$TAG.tar.gz"
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
 ## Using [Bzlmod] with Bazel 6:
@@ -28,7 +30,7 @@ http_archive(
     name = "aspect_rules_swc",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_swc/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/rules_swc/releases/download/${TAG}/${ARCHIVE}",
 )
 EOF
 


### PR DESCRIPTION
GitHub's stability guarantee for the archive is iffy, and we want metrics on downloads. See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1411222578