### PR TITLE
chore: update to swc v1.3.36

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,10 +18,10 @@ swc_register_toolchains(
     name = "swc",
     # Demonstrates how users can choose ANY swc version, not just the ones we mirrored
     integrity_hashes = {
-        "darwin-arm64": "sha384-87HERB0qZ2UqjSxLMpQB7EtYASe7ovT36pPtj409p6eDtM9dAEEXQS10nJ/OOz3O",
-        "darwin-x64": "sha384-i3poY6tNdi83tkpaV+uDgTR1jYxHIXzeqS1KAi8+DZKHUvwlyEXmwDWly0kZPWDs",
-        "linux-arm64-gnu": "sha384-2Q5viIs4jkFd/H0abMrUhZP/ILfY3S3GceoU9vBfRfJgCj+GF9SARoCQa7cRYEBb",
-        "linux-x64-gnu": "sha384-k5POzu1Ub30FlqagD+Voq5vE/pwB6SB4WD2SH5Yg/ALdC7pligR0avdRyFjVZ2oS",
+        "darwin-arm64": "sha384-uMvEbYqK976Hh84Ev0sVuehadekaB1qsv8bjvXOTs6fvBhBjTr2TH9zUY6/xrRuI",
+        "darwin-x64": "sha384-p4CvXYeEinS1fGcklKl7X70+PpKETyBSL9YGofqG+RoJ/RzlhBKO6e/JSN9/6yPf",
+        "linux-arm64-gnu": "sha384-DghqoJEVmKj7qPjbviROs/DVfFucAORFSry7Lqqm11Jrol46UnpMq2BiWmovTzPV",
+        "linux-x64-gnu": "sha384-PwxqpU1ROBuiGtRdMGaupnNR2NjEUu+loz7rn9mOmf0wSuOmStRNm4SsStfCpgBq",
     },
     swc_version_from = "//:package.json",
 )

--- a/examples/custom_outs/BUILD.bazel
+++ b/examples/custom_outs/BUILD.bazel
@@ -32,7 +32,7 @@ assert_outputs(
         name = "compile_" + format,
         srcs = ["a.ts"],
         args = [
-            "--config",
+            "--config-json",
             """{"module": {"type": "%s"}}""" % format,
         ],
         # The extension of the outputs can be modified using js_outs

--- a/examples/paths/.swcrc
+++ b/examples/paths/.swcrc
@@ -4,9 +4,11 @@
       "syntax": "typescript"
     },
     "target": "es2021",
-    "baseUrl": "examples/paths",
+    "baseUrl": "./src",
     "paths": {
-      "@modules/*": ["./src/modules/*"]
+      "@modules/*": [
+        "./modules/*"
+      ]
     }
   },
   "module": {

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -18,8 +18,8 @@ assert_json_matches(
     name = "check_paths",
     file1 = "tsconfig.json",
     file2 = ".swcrc",
-    filter1 = ".compilerOptions.paths",
-    filter2 = ".jsc.paths",
+    filter1 = ".compilerOptions.paths, .compilerOptions.baseUrl",
+    filter2 = ".jsc.paths, .jsc.baseUrl",
 )
 
 write_source_files(

--- a/examples/paths/expected.js
+++ b/examples/paths/expected.js
@@ -2,5 +2,5 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _moduleA = require("./modules/moduleA");
+const _moduleA = require("./modules/moduleA/index");
 (0, _moduleA.moduleA)();

--- a/examples/paths/tsconfig.json
+++ b/examples/paths/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
     "paths": {
-      "@modules/*": ["./src/modules/*"]
+      "@modules/*": ["./modules/*"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "// this file only used for WORKSPACE to infer our version of swc": "",
   "devDependencies": {
-    "@swc/core": "1.3.34"
+    "@swc/core": "1.3.36"
   }
 }

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -189,7 +189,7 @@ def _impl(ctx):
     plugin_args = []
     if ctx.attr.plugins:
         plugin_cache = [ctx.actions.declare_directory("{}_plugin_cache".format(ctx.label.name))]
-        plugin_args = ["--config", json.encode({
+        plugin_args = ["--config-json", json.encode({
             "jsc": {
                 "experimental": {
                     "cacheRoot": plugin_cache[0].path,

--- a/swc/private/versions.bzl
+++ b/swc/private/versions.bzl
@@ -2,6 +2,16 @@
 
 # Versions should be descending order so TOOL_VERSIONS[0] is the latest version.
 TOOL_VERSIONS = {
+    "v1.3.36": {
+        "darwin-arm64": "sha384-uMvEbYqK976Hh84Ev0sVuehadekaB1qsv8bjvXOTs6fvBhBjTr2TH9zUY6/xrRuI",
+        "darwin-x64": "sha384-p4CvXYeEinS1fGcklKl7X70+PpKETyBSL9YGofqG+RoJ/RzlhBKO6e/JSN9/6yPf",
+        "linux-arm-gnueabihf": "sha384-LSxpJ59ZVa2O/KIZuWiHKOoclhEAoUXoi1oeUwMLfEiTAeX0ZwiAvtK1pgHInqqS",
+        "linux-arm64-gnu": "sha384-DghqoJEVmKj7qPjbviROs/DVfFucAORFSry7Lqqm11Jrol46UnpMq2BiWmovTzPV",
+        "linux-x64-gnu": "sha384-PwxqpU1ROBuiGtRdMGaupnNR2NjEUu+loz7rn9mOmf0wSuOmStRNm4SsStfCpgBq",
+        "win32-arm64-msvc": "sha384-NjRz1MgDghi5dxcDJFmnGX8oifL1y1UGKU0FE8O+x40Kri5qEJjEYGQxahGNEVMy",
+        "win32-ia32-msvc": "sha384-6sEP3EiORWnGTMcMPsIqj5x25JogO8nA5eQs5sU7C6xm+wWEYWLcr1kczphu5qgW",
+        "win32-x64-msvc": "sha384-ocyZh77sV7W1BTYHhH4sKbvdZg2wrJjl43I7HI1B5MLecGGZ6n7aOydoI/npmsVF",
+    },
     "v1.3.35": {
         "darwin-arm64": "sha384-sG4QGIP6wugBRMwXBT3b5AiSI2fHRPI1OMKLZQ8N6/4ztTthRZn5Tg0IBuJIcUyL",
         "darwin-x64": "sha384-oFlWDyXjgxFBjq4HpESNQrIwd9SlIwFXvYLNa+Vm+KXODz6a2xidTJnm5qaZclDD",

--- a/swc/tests/versions_test.bzl
+++ b/swc/tests/versions_test.bzl
@@ -10,7 +10,7 @@ def _smoke_test_impl(ctx):
 
     # TODO: assert instead that the TOOL_VERSIONS.keys()[0] is the newest version
     # and version numbers down from there are descending
-    asserts.equals(env, "v1.3.35", TOOL_VERSIONS.keys()[0])
+    asserts.equals(env, "v1.3.36", TOOL_VERSIONS.keys()[0])
     return unittest.end(env)
 
 # The unittest library requires that we export the test cases as named test rules,


### PR DESCRIPTION
The `--config` flag was renamed to `--config-json`, so plugin support will only work with versions >= 1.3.36 going forward.

@realtimetodie It looks like module path handling may have been broken by swc-project/swc#6930, do you understand what is going on here?

```
Executing tests from //examples/paths:test_test
-----------------------------------------------------------------------------
5c5
< const _moduleA = require("../../../../../home/codespace/.cache/bazel/_bazel_codespace/8740319a112a77c7681d8f1244e5cd69/sandbox/linux-sandbox/11/execroot/aspect_rules_swc/examples/paths/src/modules/moduleA");
---
> const _moduleA = require("./modules/moduleA");
FAIL: files "examples/paths/src/index.js" and "examples/paths/expected.js" differ. 

@//examples/paths:expected.js is out of date. To update this file, run:

    bazel run //examples/paths:test
```