### PR TITLE
fix: set sourcemap root to the workspace relative root_dir

### DIFF
--- a/examples/filegroup/BUILD.bazel
+++ b/examples/filegroup/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
     srcs = [
         "a.ts",
         "b.ts",
+        "sub/c.ts",
     ],
 )
 

--- a/examples/filegroup/check_outputs.sh
+++ b/examples/filegroup/check_outputs.sh
@@ -5,10 +5,15 @@ cd "$TEST_SRCDIR/$TEST_WORKSPACE/$(dirname $TEST_TARGET)"
 
 grep "export var a" filegroup/a.js
 grep "sourceMappingURL=a.js.map" filegroup/a.js
-grep --fixed-strings '"sourceRoot":"examples/filegroup"' filegroup/a.js.map
+grep --fixed-strings '"sourceRoot":""' filegroup/a.js.map
 grep --fixed-strings '"sources":["a.ts"]' filegroup/a.js.map
 
 grep "export var b" filegroup/b.js
 grep "sourceMappingURL=b.js.map" filegroup/b.js
-grep --fixed-strings '"sourceRoot":"examples/filegroup"' filegroup/b.js.map
+grep --fixed-strings '"sourceRoot":""' filegroup/b.js.map
 grep --fixed-strings '"sources":["b.ts"]' filegroup/b.js.map
+
+grep "export var c" filegroup/sub/c.js
+grep "sourceMappingURL=c.js.map" filegroup/sub/c.js
+grep --fixed-strings '"sourceRoot":""' filegroup/sub/c.js.map
+grep --fixed-strings '"sources":["c.ts"]' filegroup/sub/c.js.map

--- a/examples/filegroup/sub/c.ts
+++ b/examples/filegroup/sub/c.ts
@@ -1,0 +1,1 @@
+export const c: string = "c";

--- a/examples/out_dir/BUILD.bazel
+++ b/examples/out_dir/BUILD.bazel
@@ -6,6 +6,7 @@ swc(
     srcs = [
         "a.ts",
         "b.ts",
+        "sub/c.ts",
     ],
     out_dir = "out",
     source_maps = True,
@@ -19,5 +20,7 @@ write_source_files(
         "expected/a.js.map": ":out/a.js.map",
         "expected/b.js": ":out/b.js",
         "expected/b.js.map": ":out/b.js.map",
+        "expected/sub/c.js": ":out/sub/c.js",
+        "expected/sub/c.js.map": ":out/sub/c.js.map",
     },
 )

--- a/examples/out_dir/expected/a.js.map
+++ b/examples/out_dir/expected/a.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["a.ts"],"sourceRoot":"examples/out_dir","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../a.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/out_dir/expected/b.js.map
+++ b/examples/out_dir/expected/b.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["b.ts"],"sourceRoot":"examples/out_dir","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../b.ts"],"sourceRoot":"","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/out_dir/expected/sub/c.js
+++ b/examples/out_dir/expected/sub/c.js
@@ -1,0 +1,3 @@
+export var c = "c";
+
+//# sourceMappingURL=c.js.map

--- a/examples/out_dir/expected/sub/c.js.map
+++ b/examples/out_dir/expected/sub/c.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["../../sub/c.ts"],"sourceRoot":"","sourcesContent":["export const c: string = \"c\";\n"],"names":["c"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/out_dir/sub/c.ts
+++ b/examples/out_dir/sub/c.ts
@@ -1,0 +1,1 @@
+export const c: string = "c";

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,3 +1,6 @@
 {
-  "private": true
+  "private": true,
+  "dependencies": {
+    "source-map-support": "^0.5.21"
+  }
 }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -1,8 +1,12 @@
 lockfileVersion: 5.4
 
 importers:
+
   .:
-    specifiers: {}
+    specifiers:
+      source-map-support: ^0.5.21
+    dependencies:
+      source-map-support: 0.5.21
 
   generate_swcrc:
     specifiers:
@@ -12,50 +16,48 @@ importers:
 
   plugins:
     specifiers:
-      "@swc/plugin-transform-imports": 1.5.41
+      '@swc/plugin-transform-imports': 1.5.41
     devDependencies:
-      "@swc/plugin-transform-imports": 1.5.41
+      '@swc/plugin-transform-imports': 1.5.41
 
 packages:
+
   /@swc/plugin-transform-imports/1.5.41:
-    resolution:
-      {
-        integrity: sha512-sywDxWfKg3Jqm7s7X81uN9P6HbrX9oBYF8lHYzT6/1c/ovVG3RGG/1bDOQpzb+IC7C/h2oI2ESOKMKibbKsq1Q==,
-      }
+    resolution: {integrity: sha512-sywDxWfKg3Jqm7s7X81uN9P6HbrX9oBYF8lHYzT6/1c/ovVG3RGG/1bDOQpzb+IC7C/h2oI2ESOKMKibbKsq1Q==}
     dev: true
 
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: false
+
   /deepmerge/4.2.2:
-    resolution:
-      {
-        integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==,
-        registry: https://registry.npmjs.com/,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==, registry: https://registry.npmjs.com/}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /joycon/3.1.1:
-    resolution:
-      {
-        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
-        registry: https://registry.npmjs.com/,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==, registry: https://registry.npmjs.com/}
+    engines: {node: '>=10'}
     dev: true
 
   /jsonc-parser/3.2.0:
-    resolution:
-      {
-        integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==,
-        registry: https://registry.npmjs.com/,
-      }
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==, registry: https://registry.npmjs.com/}
     dev: true
 
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: false
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /tsconfig-to-swcconfig/2.0.1:
-    resolution:
-      {
-        integrity: sha512-GD4rQFgw2Vdi9D81eO7F0OfKZPiBPdyB5mwbUgnGqD3jWBT8dW9TDT9vLMkbyEYM+FSv09nqmbZpzAdRDni0WQ==,
-        registry: https://registry.npmjs.com/,
-      }
+    resolution: {integrity: sha512-GD4rQFgw2Vdi9D81eO7F0OfKZPiBPdyB5mwbUgnGqD3jWBT8dW9TDT9vLMkbyEYM+FSv09nqmbZpzAdRDni0WQ==, registry: https://registry.npmjs.com/}
     dependencies:
       deepmerge: 4.2.2
       joycon: 3.1.1

--- a/examples/rc/src/expected.js.map
+++ b/examples/rc/src/expected.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["in.ts"],"sourceRoot":"examples/rc/src","sourcesContent":["export const a: string = \"foo\";\n"],"names":["a"],"mappings":";;;;+BAAaA;;aAAAA;;AAAN,MAAMA,IAAY"}
+{"version":3,"sources":["in.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"foo\";\n"],"names":["a"],"mappings":";;;;+BAAaA;;aAAAA;;AAAN,MAAMA,IAAY"}

--- a/examples/root_dir/BUILD.bazel
+++ b/examples/root_dir/BUILD.bazel
@@ -6,6 +6,7 @@ swc(
     srcs = [
         "src/a.ts",
         "src/b.ts",
+        "src/sub/c.ts",
     ],
     out_dir = "out",
     root_dir = "src",

--- a/examples/root_dir/expected/a.js.map
+++ b/examples/root_dir/expected/a.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["a.ts"],"sourceRoot":"examples/root_dir/src","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../../src/a.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/root_dir/expected/b.js.map
+++ b/examples/root_dir/expected/b.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["b.ts"],"sourceRoot":"examples/root_dir/src","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../../src/b.ts"],"sourceRoot":"","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/root_dir/expected/sub/c.js
+++ b/examples/root_dir/expected/sub/c.js
@@ -1,0 +1,3 @@
+export var c = "c";
+
+//# sourceMappingURL=c.js.map

--- a/examples/root_dir/expected/sub/c.js.map
+++ b/examples/root_dir/expected/sub/c.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["c.ts"],"sourceRoot":"","sourcesContent":["export const c: string = \"c\";\n"],"names":["c"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/root_dir/src/sub/c.ts
+++ b/examples/root_dir/src/sub/c.ts
@@ -1,0 +1,1 @@
+export const c: string = "c";

--- a/examples/source_map_support/BUILD.bazel
+++ b/examples/source_map_support/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+
+exports_files([
+    "defs.bzl",
+])
+
+copy_to_bin(
+    name = "stack-trace-support",
+    srcs = ["stack-trace-support.js"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/source_map_support/defs.bzl
+++ b/examples/source_map_support/defs.bzl
@@ -1,0 +1,28 @@
+"""
+Macro wrappers around rules_js's `js_binary` and `js_test` that improve the DX of stack traces by automatically
+registering source-map-support and removing the runfiles directory prefix.
+
+Use them wherever you would use rules_js's `js_binary` and `js_test`.
+"""
+
+load("@aspect_rules_js//js:defs.bzl", _js_binary = "js_binary", _js_test = "js_test")
+
+def js_binary(data = [], node_options = [], **kwargs):
+    _js_binary(
+        data = [
+            "//examples:node_modules/source-map-support",
+            "//examples/source_map_support:stack-trace-support",
+        ] + data,
+        node_options = ["--require", "$$RUNFILES/aspect_rules_swc/examples/source_map_support/stack-trace-support"] + node_options,
+        **kwargs
+    )
+
+def js_test(data = [], node_options = [], **kwargs):
+    _js_test(
+        data = [
+            "//examples:node_modules/source-map-support",
+            "//examples/source_map_support:stack-trace-support",
+        ] + data,
+        node_options = ["--require", "$$RUNFILES/aspect_rules_swc/examples/source_map_support/stack-trace-support"] + node_options,
+        **kwargs
+    )

--- a/examples/source_map_support/stack-trace-support.js
+++ b/examples/source_map_support/stack-trace-support.js
@@ -1,0 +1,42 @@
+// See defs.bzl for where this is used and what it does.
+
+require('source-map-support/register')
+
+let basePath = process.env.RUNFILES
+  ? `${process.env.RUNFILES}/${process.env.JS_BINARY__WORKSPACE}`
+  : process.cwd()
+
+if (!basePath.endsWith('/')) {
+  basePath = basePath + '/'
+}
+
+/*
+Before:
+    Error: test
+        at foo (/private/var/tmp/_bazel_john/67beefda950d56283b98d96980e6e332/execroot/figma/bazel-out/darwin_arm64-fastbuild/bin/bazel/js/test/stack_trace_support.sh.runfiles/figma/bazel/js/test/b.js:2:11)
+        at Object.<anonymous> (/private/var/tmp/_bazel_john/67beefda950d56283b98d96980e6e332/execroot/figma/bazel-out/darwin_arm64-fastbuild/bin/bazel/js/test/stack_trace_support.sh.runfiles/figma/bazel/js/test/a.js:4:1)
+        ...
+
+After:
+    Error: test
+        at foo (bazel/js/test/b.ts:2:9)
+        at Object.<anonymous> (bazel/js/test/a.ts:5:1)
+        ...
+*/
+
+const basePathRegex = new RegExp(
+  `(at | \\()${basePath
+    .replace(/\\/g, '/')
+    // Escape regex meta-characters.
+    .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+    .replace(/-/g, '\\x2d')}`,
+  'g',
+)
+
+const prepareStackTrace = Error.prepareStackTrace
+Error.prepareStackTrace = function (error, stack) {
+  return prepareStackTrace(error, stack)
+    .split('\n')
+    .map((line) => line.replace(basePathRegex, '$1'))
+    .join('\n')
+}

--- a/examples/source_map_support/test/BUILD.bazel
+++ b/examples/source_map_support/test/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("//examples/source_map_support:defs.bzl", "js_test")
+
+swc(
+    name = "compile",
+    srcs = [
+        "a.ts",
+        "b.ts",
+    ],
+    source_maps = True,
+)
+
+js_test(
+    name = "stack_trace_support_test",
+    data = [":compile"],
+    entry_point = ":a.js",
+)
+
+js_test(
+    name = "stack_trace_support_with_chdir_test",
+    chdir = "examples",
+    data = [":compile"],
+    entry_point = ":a.js",
+)

--- a/examples/source_map_support/test/a.ts
+++ b/examples/source_map_support/test/a.ts
@@ -1,0 +1,17 @@
+try {
+  require('./b')()
+} catch (e) {
+  const assert = require('assert')
+  const frames = e.stack
+    .split('\n')
+    .slice(1)
+    .map((s) => s.trim())
+  assert.deepEqual(
+    frames.filter((f) => f.includes('source_map_support/test/a')),
+    [`at Object.<anonymous> (examples/source_map_support/test/a.ts:2:11)`],
+  )
+  assert.deepEqual(
+    frames.filter((f) => f.includes('source_map_support/test/b')),
+    [`at foo (examples/source_map_support/test/b.ts:2:9)`],
+  )
+}

--- a/examples/source_map_support/test/b.ts
+++ b/examples/source_map_support/test/b.ts
@@ -1,0 +1,3 @@
+module.exports = function foo() {
+  throw new Error('test')
+}

--- a/examples/source_root/expected_subdir.js.map
+++ b/examples/source_root/expected_subdir.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["subdir.ts"],"sourceRoot":"../../../debug/source","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../src/subdir.ts"],"sourceRoot":"../../../debug/source","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}


### PR DESCRIPTION
This makes the sourcemap `sources` and `sourceRoot` align with tsc (when invoked from `ts_project` EDIT: and not in a worker, and properly sandboxed, and probably other conditions for it to be the "normal" case). This is comparing a `ts_project` in silo, tsc vs swc

~~The `sourcesContent` is relative to the `swc(root_dir)`, the `sourceRoot` is relative to the workspace root and includes the `root_dir`.~~

The map file `sources` is relative to the map, so when there is 1 .map per .js it is just the filename.
The `sourceRoot` is basically just a prefix and we just set it to what the user specifies (https://github.com/aspect-build/rules_swc/pull/177)