### PR TITLE
feat: add a new source_root attribute

### DIFF
--- a/docs/swc.md
+++ b/docs/swc.md
@@ -20,7 +20,7 @@ swc(
 
 <pre>
 swc_compile(<a href="#swc_compile-name">name</a>, <a href="#swc_compile-args">args</a>, <a href="#swc_compile-data">data</a>, <a href="#swc_compile-js_outs">js_outs</a>, <a href="#swc_compile-map_outs">map_outs</a>, <a href="#swc_compile-out_dir">out_dir</a>, <a href="#swc_compile-output_dir">output_dir</a>, <a href="#swc_compile-plugins">plugins</a>, <a href="#swc_compile-root_dir">root_dir</a>,
-            <a href="#swc_compile-source_maps">source_maps</a>, <a href="#swc_compile-srcs">srcs</a>, <a href="#swc_compile-swcrc">swcrc</a>)
+            <a href="#swc_compile-source_maps">source_maps</a>, <a href="#swc_compile-source_root">source_root</a>, <a href="#swc_compile-srcs">srcs</a>, <a href="#swc_compile-swcrc">swcrc</a>)
 </pre>
 
 Underlying rule for the `swc` macro.
@@ -46,7 +46,8 @@ for example to set your own output labels for `js_outs`.
 | <a id="swc_compile-output_dir"></a>output_dir |  Whether to produce a directory output rather than individual files.<br><br>        If out_dir is also specified, it is used as the name of the output directory.         Otherwise, the directory is named the same as the target.   | Boolean | optional | <code>False</code> |
 | <a id="swc_compile-plugins"></a>plugins |  swc compilation plugins, created with swc_plugin rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="swc_compile-root_dir"></a>root_dir |  a subdirectory under the input package which should be consider the root directory of all the input files   | String | optional | <code>""</code> |
-| <a id="swc_compile-source_maps"></a>source_maps |  see https://swc.rs/docs/usage/cli#--source-maps--s   | String | optional | <code>"false"</code> |
+| <a id="swc_compile-source_maps"></a>source_maps |  Create source map files for emitted JavaScript files.<br><br>        see https://swc.rs/docs/usage/cli#--source-maps--s   | String | optional | <code>"false"</code> |
+| <a id="swc_compile-source_root"></a>source_root |  Specify the root path for debuggers to find the reference source code.<br><br>        see https://swc.rs/docs/usage/cli#--source-root   | String | optional | <code>""</code> |
 | <a id="swc_compile-srcs"></a>srcs |  source files, typically .ts files in the source tree   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="swc_compile-swcrc"></a>swcrc |  label of a configuration file for swc, see https://swc.rs/docs/configuration/swcrc   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 

--- a/examples/source_root/BUILD.bazel
+++ b/examples/source_root/BUILD.bazel
@@ -7,8 +7,17 @@ swc(
     name = "compile",
     srcs = ["in.ts"],
     source_maps = True,
-    # The custom location can be a path or an URL
+    # The custom location can an URL
     source_root = "https://my-website.com/debug/source/",
+)
+
+swc(
+    name = "compile_subdir",
+    srcs = ["src/subdir.ts"],
+    root_dir = "src",
+    source_maps = True,
+    # The custom location can be a path
+    source_root = "../../../debug/source",
 )
 
 # Assert that the output of "compile" rule matches the expected file.
@@ -17,5 +26,14 @@ write_source_files(
     files = {
         "expected.js": ":in.js",
         "expected.js.map": ":in.js.map",
+    },
+)
+
+# Assert that the output of "compile_subdir" rule matches the expected file.
+write_source_files(
+    name = "test_subdir",
+    files = {
+        "expected_subdir.js": ":subdir.js",
+        "expected_subdir.js.map": ":subdir.js.map",
     },
 )

--- a/examples/source_root/BUILD.bazel
+++ b/examples/source_root/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+
+# Specifies a custom location where a debugger should locate source files instead of relative source 
+# locations. This string is treated verbatim inside the source-map where you can use a path or a URL.
+swc(
+    name = "compile",
+    srcs = ["in.ts"],
+    source_maps = True,
+    # The custom location can be a path or an URL
+    source_root = "https://my-website.com/debug/source/",
+)
+
+# Assert that the output of "compile" rule matches the expected file.
+write_source_files(
+    name = "test",
+    files = {
+        "expected.js": ":in.js",
+        "expected.js.map": ":in.js.map",
+    },
+)

--- a/examples/source_root/expected.js
+++ b/examples/source_root/expected.js
@@ -1,0 +1,3 @@
+export var a = "foo";
+
+//# sourceMappingURL=in.js.map

--- a/examples/source_root/expected.js.map
+++ b/examples/source_root/expected.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["in.ts"],"sourceRoot":"https://my-website.com/debug/source/","sourcesContent":["export const a: string = \"foo\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,MAAM"}

--- a/examples/source_root/expected_subdir.js
+++ b/examples/source_root/expected_subdir.js
@@ -1,0 +1,3 @@
+export var a = "a";
+
+//# sourceMappingURL=subdir.js.map

--- a/examples/source_root/expected_subdir.js.map
+++ b/examples/source_root/expected_subdir.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["subdir.ts"],"sourceRoot":"../../../debug/source","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/source_root/in.ts
+++ b/examples/source_root/in.ts
@@ -1,0 +1,1 @@
+export const a: string = "foo";

--- a/examples/source_root/src/subdir.ts
+++ b/examples/source_root/src/subdir.ts
@@ -1,0 +1,1 @@
+export const a: string = "a";

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -23,9 +23,17 @@ _attrs = {
         """,
     ),
     "source_maps": attr.string(
-        doc = "see https://swc.rs/docs/usage/cli#--source-maps--s",
+        doc = """Create source map files for emitted JavaScript files.
+
+        see https://swc.rs/docs/usage/cli#--source-maps--s""",
         values = ["true", "false", "inline", "both"],
         default = "false",
+    ),
+    "source_root": attr.string(
+        doc = """Specify the root path for debuggers to find the reference source code.
+
+        see https://swc.rs/docs/usage/cli#--source-root""",
+        default = "",
     ),
     "output_dir": attr.bool(
         doc = """Whether to produce a directory output rather than individual files.
@@ -247,7 +255,7 @@ def _impl(ctx):
         for src in ctx.files.srcs:
             src_args = ctx.actions.args()
             src_args.add("--source-file-name", src.basename)
-            src_args.add("--source-root", src.dirname)
+            src_args.add("--source-root", src.dirname if ctx.attr.source_root == "" else ctx.attr.source_root)
 
             src_path = _relative_to_package(src.path, ctx)
 


### PR DESCRIPTION
Allows the user to specify a custom location where a debugger should locate source files.

This imitates the TSConfig `sourceRoot` configuration option

https://www.typescriptlang.org/tsconfig#sourceRoot

Example

```starlark
swc(
    name = "compile",
    source_maps = True,
    source_root = "https://my-website.com/debug/source/",
)
```

The `source_root` attribute is optional.

Related

- #176