### PR TITLE
fix: do not specify empty --source-root arg

### DIFF
--- a/examples/filegroup/check_outputs.sh
+++ b/examples/filegroup/check_outputs.sh
@@ -5,15 +5,15 @@ cd "$TEST_SRCDIR/$TEST_WORKSPACE/$(dirname $TEST_TARGET)"
 
 grep "export var a" filegroup/a.js
 grep "sourceMappingURL=a.js.map" filegroup/a.js
-grep --fixed-strings '"sourceRoot":""' filegroup/a.js.map
+grep -v --fixed-strings '"sourceRoot"' filegroup/a.js.map
 grep --fixed-strings '"sources":["a.ts"]' filegroup/a.js.map
 
 grep "export var b" filegroup/b.js
 grep "sourceMappingURL=b.js.map" filegroup/b.js
-grep --fixed-strings '"sourceRoot":""' filegroup/b.js.map
+grep -v --fixed-strings '"sourceRoot"' filegroup/b.js.map
 grep --fixed-strings '"sources":["b.ts"]' filegroup/b.js.map
 
 grep "export var c" filegroup/sub/c.js
 grep "sourceMappingURL=c.js.map" filegroup/sub/c.js
-grep --fixed-strings '"sourceRoot":""' filegroup/sub/c.js.map
+grep -v --fixed-strings '"sourceRoot"' filegroup/sub/c.js.map
 grep --fixed-strings '"sources":["c.ts"]' filegroup/sub/c.js.map

--- a/examples/out_dir/expected/a.js.map
+++ b/examples/out_dir/expected/a.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../a.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../a.ts"],"sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/out_dir/expected/b.js.map
+++ b/examples/out_dir/expected/b.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../b.ts"],"sourceRoot":"","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../b.ts"],"sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/out_dir/expected/sub/c.js.map
+++ b/examples/out_dir/expected/sub/c.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../../sub/c.ts"],"sourceRoot":"","sourcesContent":["export const c: string = \"c\";\n"],"names":["c"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../../sub/c.ts"],"sourcesContent":["export const c: string = \"c\";\n"],"names":["c"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/rc/src/expected.js.map
+++ b/examples/rc/src/expected.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["in.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"foo\";\n"],"names":["a"],"mappings":";;;;+BAAaA;;aAAAA;;AAAN,MAAMA,IAAY"}
+{"version":3,"sources":["in.ts"],"sourcesContent":["export const a: string = \"foo\";\n"],"names":["a"],"mappings":";;;;+BAAaA;;aAAAA;;AAAN,MAAMA,IAAY"}

--- a/examples/root_dir/expected/a.js.map
+++ b/examples/root_dir/expected/a.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../../src/a.ts"],"sourceRoot":"","sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../../src/a.ts"],"sourcesContent":["export const a: string = \"a\";\n"],"names":["a"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/examples/root_dir/expected/b.js.map
+++ b/examples/root_dir/expected/b.js.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../../src/b.ts"],"sourceRoot":"","sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}
+{"version":3,"sources":["../../src/b.ts"],"sourcesContent":["export const b: string = \"b\";\n"],"names":["b"],"mappings":"AAAA,OAAO,IAAMA,IAAY,IAAI"}

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -275,7 +275,8 @@ def _impl(ctx):
         for src in ctx.files.srcs:
             src_args = ctx.actions.args()
             src_args.add("--source-file-name", _calculate_source_file(ctx, src))
-            src_args.add("--source-root", ctx.attr.source_root)
+            if ctx.attr.source_root:
+                src_args.add("--source-root", ctx.attr.source_root)
 
             src_path = _relative_to_package(src.path, ctx)
 


### PR DESCRIPTION
The spec says the "sourceRoot" is optional, so empty should be the same as not specified.

See https://sourcemaps.info/spec.html#h.qz3o9nc69um5