### PR TITLE
Fix bzl_library dependencies of dependencies.bzl

### DIFF
--- a/examples/source_map_support/BUILD.bazel
+++ b/examples/source_map_support/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 exports_files([
@@ -8,4 +9,11 @@ copy_to_bin(
     name = "stack-trace-support",
     srcs = ["stack-trace-support.js"],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@aspect_rules_js//js:defs"],
 )

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -4,8 +4,11 @@ Users should *not* need to install these. If users see a load()
 statement from these, that's a bug in our distribution.
 """
 
-# buildifier: disable=bzl-visibility
-load("//swc/private:maybe.bzl", http_archive = "maybe_http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 def rules_swc_internal_deps():
     "Fetch deps needed for local development"

--- a/swc/BUILD.bazel
+++ b/swc/BUILD.bazel
@@ -39,8 +39,7 @@ bzl_library(
     srcs = ["dependencies.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+        "//swc/private:maybe",
     ],
 )
 

--- a/swc/BUILD.bazel
+++ b/swc/BUILD.bazel
@@ -39,7 +39,8 @@ bzl_library(
     srcs = ["dependencies.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "//swc/private:maybe",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
 

--- a/swc/dependencies.bzl
+++ b/swc/dependencies.bzl
@@ -6,7 +6,11 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 Replaced by bzlmod for users of Bazel 6.0 and above.
 """
 
-load("//swc/private:maybe.bzl", http_archive = "maybe_http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 def rules_swc_dependencies():
     http_archive(

--- a/swc/private/BUILD.bazel
+++ b/swc/private/BUILD.bazel
@@ -20,16 +20,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "maybe",
-    srcs = ["maybe.bzl"],
-    visibility = ["//swc:__subpackages__"],
-    deps = [
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ],
-)
-
-bzl_library(
     name = "resolved_toolchain",
     srcs = ["resolved_toolchain.bzl"],
     visibility = ["//swc:__subpackages__"],

--- a/swc/private/maybe.bzl
+++ b/swc/private/maybe.bzl
@@ -1,7 +1,0 @@
-"maybe utilities"
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-def maybe_http_archive(**kwargs):
-    maybe(_http_archive, **kwargs)


### PR DESCRIPTION
Was likely just forgotten in 4e44b7368ccda4422c8d00597fda59edb203be35.

### Type of change
- Bug fix

### Test plan
- Untested (review only).