### PR TITLE
doc: Add documentation for using your own swc version

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -45,9 +45,25 @@ swc_register_toolchains(
         "linux-arm64-gnu": "sha384-iaBhMLrnHTSfXa86AVHM6zHqYbH3Fh1dWwDeH7sW9HKvX2gbQb6LOpWN6Wp4ddud",
         "linux-x64-gnu": "sha384-R/y9mcodpNt8l6DulUCG5JsNMrApP+vOAAh3bTRChh6LQKP0Z3Fwq86ztfObpAH8",
     },
-    swc_version = "1.3.37",
+    swc_version = "v1.3.37",
 )
 ```
+
+You can use the [`mirror_releases.sh` script](https://github.com/aspect-build/rules_swc/blob/main/scripts/mirror_releases.sh) to generate the expected shas. For example:
+```
+&gt; mirror_releases.sh v1.3.50
+    "v1.3.50": {
+        "darwin-arm64": "sha384-kXrPSxzwUCsB2y0ivQrCrBDULa+N9BwwtKzqo4hIgYmgZgBGP8cXfEWlM18Pe2mT",
+        "darwin-x64": "sha384-xRo3yRFsS8w5I7uWG7ZDpDiIhlJVUADpXzCWCNkYEsO4vJGD3izvTCUyWcF6HaRj",
+        "linux-arm-gnueabihf": "sha384-WoVw65RR2yq7fZGRpGKGDwyloteD2XjxMkqVDip2BkKuGVZMDjqldivLYx56Nhzq",
+        "linux-arm64-gnu": "sha384-f1pB/FU6PVYSW8KIFA799chHgXPeoaH2z8E82Mc2V21pQeJWITasy5h5wPHghZ9i",
+        "linux-x64-gnu": "sha384-MdR0sNOSZG4AfCBQFfqSGJ5A9Zi5mMgL7wdIeQpzqjkPICK2uDl5/MgJbO4D3kAM",
+        "win32-arm64-msvc": "sha384-PSmCSGrZBoFg8D+S7NqmlVr4HSedlWU2IsF0eci9jUQb+eBJeco3IO4V+IIhCiKw",
+        "win32-ia32-msvc": "sha384-HXRGllEV7LnLN/tgB5FfspniKG3y43C1bKIatDQIWk56gekAzm1ntV1W0qAYjz3M",
+        "win32-x64-msvc": "sha384-0oZDYXsh1Aeiqt9jA/HcWEM/yMXoC7fQvkPhDjUf0nVimZuPehj4BPWCyiIsrD1s",
+    },
+```
+
 
 
 <a id="swc_repositories"></a>

--- a/scripts/mirror_releases.sh
+++ b/scripts/mirror_releases.sh
@@ -2,17 +2,29 @@
 
 set -o errexit -o nounset -o pipefail
 
-releases=$(curl -sSL -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/swc-project/swc/releases?per_page=1 | jq -f $(pwd)/scripts/filter.jq)
+requested_version="${1-}"
+url="https://api.github.com/repos/swc-project/swc/releases"
+
+if [[ -z "$requested_version" ]]; then
+  url="${url}?per_page=1"
+else
+  # Get a lot of releases to match against.
+  url="${url}?per_page=50"
+fi
+
+releases=$(curl -sSL -H 'Accept: application/vnd.github.v3+json' $url | jq -f $(pwd)/scripts/filter.jq)
 versions=$(echo $releases | jq --raw-output 'keys[]')
 
 for version in $versions; do
-    echo "    \"$version\": {"
-    assets=$(echo $releases | jq --raw-output --arg v "$version" '.["\($v)"] | keys[]')
-    for asset in $assets; do
-        url=$(echo $releases | jq --raw-output --arg v "$version" --arg a "$asset" '.["\($v)"] | .["\($a)"]')
-        echo "        \"${asset%.exe}\": \"sha384-$(curl -sSL $url | shasum -b -a 384 | awk "{ print \$1 }" | xxd -r -p | base64)\","
-    done
-    echo "    },"
+    if [[ -z "$requested_version" ]] || [[ "$requested_version" == "$version" ]]; then
+        echo "    \"$version\": {"
+        assets=$(echo $releases | jq --raw-output --arg v "$version" '.["\($v)"] | keys[]')
+        for asset in $assets; do
+            url=$(echo $releases | jq --raw-output --arg v "$version" --arg a "$asset" '.["\($v)"] | .["\($a)"]')
+            echo "        \"${asset%.exe}\": \"sha384-$(curl -sSL $url | shasum -b -a 384 | awk "{ print \$1 }" | xxd -r -p | base64)\","
+        done
+        echo "    },"
+    fi
 done
 
 echo "Now, paste the above output into swc/private/versions.bzl as the first entry in TOOL_VERSIONS"

--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -43,9 +43,25 @@ swc_register_toolchains(
         "linux-arm64-gnu": "sha384-iaBhMLrnHTSfXa86AVHM6zHqYbH3Fh1dWwDeH7sW9HKvX2gbQb6LOpWN6Wp4ddud",
         "linux-x64-gnu": "sha384-R/y9mcodpNt8l6DulUCG5JsNMrApP+vOAAh3bTRChh6LQKP0Z3Fwq86ztfObpAH8",
     },
-    swc_version = "1.3.37",
+    swc_version = "v1.3.37",
 )
 ```
+
+You can use the [`mirror_releases.sh` script](https://github.com/aspect-build/rules_swc/blob/main/scripts/mirror_releases.sh) to generate the expected shas. For example:
+```
+> mirror_releases.sh v1.3.50
+    "v1.3.50": {
+        "darwin-arm64": "sha384-kXrPSxzwUCsB2y0ivQrCrBDULa+N9BwwtKzqo4hIgYmgZgBGP8cXfEWlM18Pe2mT",
+        "darwin-x64": "sha384-xRo3yRFsS8w5I7uWG7ZDpDiIhlJVUADpXzCWCNkYEsO4vJGD3izvTCUyWcF6HaRj",
+        "linux-arm-gnueabihf": "sha384-WoVw65RR2yq7fZGRpGKGDwyloteD2XjxMkqVDip2BkKuGVZMDjqldivLYx56Nhzq",
+        "linux-arm64-gnu": "sha384-f1pB/FU6PVYSW8KIFA799chHgXPeoaH2z8E82Mc2V21pQeJWITasy5h5wPHghZ9i",
+        "linux-x64-gnu": "sha384-MdR0sNOSZG4AfCBQFfqSGJ5A9Zi5mMgL7wdIeQpzqjkPICK2uDl5/MgJbO4D3kAM",
+        "win32-arm64-msvc": "sha384-PSmCSGrZBoFg8D+S7NqmlVr4HSedlWU2IsF0eci9jUQb+eBJeco3IO4V+IIhCiKw",
+        "win32-ia32-msvc": "sha384-HXRGllEV7LnLN/tgB5FfspniKG3y43C1bKIatDQIWk56gekAzm1ntV1W0qAYjz3M",
+        "win32-x64-msvc": "sha384-0oZDYXsh1Aeiqt9jA/HcWEM/yMXoC7fQvkPhDjUf0nVimZuPehj4BPWCyiIsrD1s",
+    },
+```
+
 """
 
 load("@bazel_skylib//lib:versions.bzl", "versions")


### PR DESCRIPTION
additionally, updates `mirror_releases.sh` so it can be run to retrieve a single specific version and its hashes.

---

### Type of change

- Documentation (updates to documentation or READMEs)

**For changes visible to end-users**

- Relevant documentation has been updated

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - Executed `mirror_releases.sh` both with a version to search for and without, to ensure it still worked in both cases.
