### PR TITLE
test: paths should resolve without sandbox directories

### DIFF
--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -28,3 +28,10 @@ write_source_files(
         "expected.js": "src/index.js",
     },
 )
+
+write_source_files(
+    name = "test_module_a",
+    files = {
+        "moduleA.expected.js": "src/modules/moduleA/index.js",
+    },
+)

--- a/examples/paths/moduleA.expected.js
+++ b/examples/paths/moduleA.expected.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "moduleA", {
+    enumerable: true,
+    get: function() {
+        return moduleA;
+    }
+});
+const _moduleB = require("../moduleB");
+const moduleA = ()=>{
+    console.log("This is module A");
+    (0, _moduleB.moduleB)();
+};


### PR DESCRIPTION
---
### Overview

I have been trying to figure out whether this issue is in SWC or `rules_swc`. For now I am going to leave this here since it is a simple reproduction of the issue I am seeing. For a more in depth reproduction of this working outside Bazel, please see: https://github.com/jackvincentnz/bazel-swc-paths-bug-repo

### Motivation
- Minimal reproduction of sandbox paths being present in transpiled javascript after swc transpilation of .ts imports using tsconfig paths.
- Bundling the transpiled sources is impossible because the resolved path is not accessible to another downstream action.

### Type of change

- Reproduction of issue

### Test plan

- New test cases added

### Summary

Sandbox paths are present in transpiled sources when the module being transformed is nested from the `baseUrl` configured in `.swcrc`. 

E.g. we expected to see paths resolved to their relative paths:
```
const _moduleB = require("../moduleB");
```

But instead we see a sandbox path:
```
const _moduleB = require("../../../../../../../../../../private/var/tmp/_bazel_jack.vincent/bfa0af320da1536c766f4c861b78e1af/sandbox/darwin-sandbox/6/execroot/aspect_rules_swc/examples/paths/src/modules/moduleB");
```