### PR TITLE
refactor: rename _impl methods with unique name

### DIFF
--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -194,7 +194,7 @@ def _swc_action(ctx, swc_binary, **kwargs):
         **kwargs
     )
 
-def _impl(ctx):
+def _swc_impl(ctx):
     swc_toolchain = ctx.toolchains["@aspect_rules_swc//swc:toolchain_type"]
 
     inputs = swc_toolchain.swcinfo.tool_files[:]
@@ -360,7 +360,7 @@ def _impl(ctx):
     ]
 
 swc = struct(
-    implementation = _impl,
+    implementation = _swc_impl,
     attrs = dict(_attrs, **_outputs),
     toolchains = ["@aspect_rules_swc//swc:toolchain_type"],
     SUPPORTED_EXTENSIONS = _SUPPORTED_EXTENSIONS,

--- a/swc/private/swc_plugin.bzl
+++ b/swc/private/swc_plugin.bzl
@@ -15,7 +15,7 @@ _attrs = {
     ),
 }
 
-def _impl(ctx):
+def _swc_plugin_impl(ctx):
     return [
         DefaultInfo(
             files = ctx.attr.src[DefaultInfo].files,
@@ -28,6 +28,6 @@ def _impl(ctx):
 
 swc_plugin = struct(
     attrs = _attrs,
-    implementation = _impl,
+    implementation = _swc_plugin_impl,
     provides = [DefaultInfo, SwcPluginConfigInfo],
 )


### PR DESCRIPTION
When looking at traces or profiles a unique name really helps.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
