### PR TITLE
chore: add test producing the typescript source-of-truth

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 docs/*.md
 **/expected.js
 **/expected.cjs
+**/expected_tsc

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,5 +2,8 @@
   "private": true,
   "dependencies": {
     "source-map-support": "^0.5.21"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
   }
 }

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -6,11 +6,33 @@ Note that this example also depends on the setup in /WORKSPACE at the root of th
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@npm//examples:typescript/package_json.bzl", "bin")
 
 # Note: The .swcrc configuration file will be automatically used, if it is present in the current directory
 swc(
     name = "compile",
     srcs = glob(["**/*.ts"]),
+)
+
+# Produce a folder of the transpiled outputs of `tsc`.
+# This is useful when reporting a bug to the SWC project, as their goal is to emit the same.
+# For example, https://github.com/swc-project/swc/issues/8265
+bin.tsc(
+    name = "tsc",
+    srcs = [
+        "src/index.ts",
+        "tsconfig.json",
+    ] + glob(["src/modules/**/*.ts"]),
+    args = [
+        "--outDir",
+        package_name() + "/tsc_out",
+        "--listFiles",
+        "-p",
+        "$(execpath tsconfig.json)",
+    ],
+    out_dirs = [
+        "tsc_out",
+    ],
 )
 
 # Verify that the "paths" entry is agreed between swc and TS language service (in the editor)
@@ -26,5 +48,6 @@ write_source_files(
     name = "test",
     files = {
         "expected.js": "src/index.js",
+        "expected_tsc": ":tsc",
     },
 )

--- a/examples/paths/expected_tsc/index.js
+++ b/examples/paths/expected_tsc/index.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var moduleA_1 = require("@modules/moduleA");
+(0, moduleA_1.moduleA)();

--- a/examples/paths/expected_tsc/modules/moduleA/index.js
+++ b/examples/paths/expected_tsc/modules/moduleA/index.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.moduleA = void 0;
+var moduleB_1 = require("@modules/moduleB");
+var moduleA = function () {
+    console.log("This is module A");
+    (0, moduleB_1.moduleB)();
+};
+exports.moduleA = moduleA;

--- a/examples/paths/expected_tsc/modules/moduleB/index.js
+++ b/examples/paths/expected_tsc/modules/moduleB/index.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.moduleB = void 0;
+var moduleB = function () { return console.log("This is module B!"); };
+exports.moduleB = moduleB;

--- a/examples/paths/tsconfig.json
+++ b/examples/paths/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": {
       "@modules/*": ["./modules/*"]
     }
-  }
+  },
+  "include": ["src/**/*"]
 }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -1,65 +1,70 @@
-lockfileVersion: 5.4
+lockfileVersion: "6.1"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
   .:
-    specifiers:
-      source-map-support: ^0.5.21
     dependencies:
-      source-map-support: 0.5.21
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: registry.npmjs.org/typescript@5.2.2
 
   generate_swcrc:
-    specifiers:
-      tsconfig-to-swcconfig: ^2.4.0
     devDependencies:
-      tsconfig-to-swcconfig: 2.4.0
+      tsconfig-to-swcconfig:
+        specifier: ^2.4.0
+        version: 2.4.0
 
   plugins:
-    specifiers:
-      "@swc/plugin-transform-imports": 1.5.70
     devDependencies:
-      "@swc/plugin-transform-imports": 1.5.70
+      "@swc/plugin-transform-imports":
+        specifier: 1.5.70
+        version: 1.5.70
 
 packages:
-  /@fastify/deepmerge/1.3.0:
+  /@fastify/deepmerge@1.3.0:
     resolution:
       {
         integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==,
-        registry: https://registry.npmjs.com/,
       }
     dev: true
 
-  /@swc/plugin-transform-imports/1.5.70:
+  /@swc/plugin-transform-imports@1.5.70:
     resolution:
       {
         integrity: sha512-cERR7gMvqiLMWyS7wWGBPWW77Mz23ss/8iAfLj5V+6CdBGYfabpAmBmqR18mvJ2qGc1Dg1GHLPN8JcMXcX95JA==,
       }
     dev: true
 
-  /buffer-from/1.1.2:
+  /buffer-from@1.1.2:
     resolution:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
       }
     dev: false
 
-  /joycon/3.1.1:
+  /joycon@3.1.1:
     resolution:
       {
         integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
-        registry: https://registry.npmjs.com/,
       }
     engines: { node: ">=10" }
     dev: true
 
-  /jsonc-parser/3.2.0:
+  /jsonc-parser@3.2.0:
     resolution:
       {
         integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==,
-        registry: https://registry.npmjs.com/,
       }
     dev: true
 
-  /source-map-support/0.5.21:
+  /source-map-support@0.5.21:
     resolution:
       {
         integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
@@ -69,7 +74,7 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /source-map/0.6.1:
+  /source-map@0.6.1:
     resolution:
       {
         integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
@@ -77,15 +82,27 @@ packages:
     engines: { node: ">=0.10.0" }
     dev: false
 
-  /tsconfig-to-swcconfig/2.4.0:
+  /tsconfig-to-swcconfig@2.4.0:
     resolution:
       {
         integrity: sha512-vT1hUG06TC3XCRQoina91VGH5HKfxYgA4hN2Ly0uNxHKNeCds++7aBE2Je62FUTKvvdkTpLjmynF8bzgYcDymA==,
-        registry: https://registry.npmjs.com/,
       }
     hasBin: true
     dependencies:
       "@fastify/deepmerge": 1.3.0
       joycon: 3.1.1
       jsonc-parser: 3.2.0
+    dev: true
+
+  registry.npmjs.org/typescript@5.2.2:
+    resolution:
+      {
+        integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==,
+        registry: https://registry.npmjs.com/,
+        tarball: https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz,
+      }
+    name: typescript
+    version: 5.2.2
+    engines: { node: ">=14.17" }
+    hasBin: true
     dev: true


### PR DESCRIPTION
The SWC project claims that their emit should match, so this helps us reason about what is "correct" behavior. We can just point them at the golden files to show what `tsc` does.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- New test cases added
