### PR TITLE
fix: use latest rules_js gather_transitive_sources signature

### DIFF
--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -329,7 +329,7 @@ def _swc_impl(ctx):
     output_sources_depset = depset(output_sources)
 
     transitive_sources = js_lib_helpers.gather_transitive_sources(
-        sources = output_sources_depset,
+        sources = output_sources,
         targets = ctx.attr.srcs,
     )
 


### PR DESCRIPTION
For compatibility with the latest rules_js v2

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
