### PR TITLE
chore: remove unneeded registration

### DIFF
--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -12,6 +12,3 @@ swc.toolchain(
     name = "swc",
     swc_version = "v1.3.78",
 )
-use_repo(swc, "swc_toolchains")
-
-register_toolchains("@swc_toolchains//:all")


### PR DESCRIPTION
Tripped over this in rules_ts where I copied the snippet, and the registration leaked into userland.

It's enough to add the tag_class, then rules_swc reads it when it registers.

---

### Changes are visible to end-users: no
