### PR TITLE
fix: align pre-calculated outputs with rules_ts

### DIFF
--- a/examples/genrule/.swcrc
+++ b/examples/genrule/.swcrc
@@ -1,0 +1,8 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    }
+  },
+  "sourceMaps": true
+}

--- a/examples/genrule/BUILD.bazel
+++ b/examples/genrule/BUILD.bazel
@@ -1,0 +1,99 @@
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+genrule(
+    name = "a",
+    outs = ["a.ts"],
+    cmd = "echo 'export const a: string = \"a\";' > $@",
+)
+
+genrule(
+    name = "b",
+    outs = ["b.ts"],
+    cmd = "echo 'export const b: string = \"b\";' > $@",
+)
+
+genrule(
+    name = "c",
+    outs = ["sub/c.ts"],
+    cmd = "echo 'export const c: string = \"c\";' > $@",
+)
+
+swc(
+    name = "compile",
+    srcs = [
+        "b.ts",
+        ":a",
+        ":sub/c.ts",
+    ],  # reference by label, output file, :outputfile
+    source_maps = True,
+    swcrc = ".swcrc",
+)
+
+build_test(
+    name = "predeclared_test",
+    targets = [
+        "b.js",
+        "b.js.map",
+        "sub/c.js",
+        "sub/c.js.map",
+    ],
+)
+
+# Since the srcs were in a filegroup, the swc macro cannot pre-declare the outputs.
+# So there is no label ":a.js" that we can reference from the build file.
+# However, a.js is still produced as one of the default outputs of the compile rule.
+# We can verify this in an action that depends on the ":compile" rule and reads the files.
+sh_test(
+    name = "check_outputs",
+    srcs = ["check_outputs.sh"],
+    data = [":compile"],
+)
+
+swc(
+    name = "compile2",
+    srcs = [
+        "b.ts",
+        ":a",
+        ":sub/c.ts",
+    ],
+    out_dir = "out2",
+    source_maps = True,
+    swcrc = ".swcrc",
+)
+
+build_test(
+    name = "out_dir_predeclared_test",
+    targets = [
+        "out2/b.js",
+        "out2/b.js.map",
+        "out2/sub/c.js",
+        "out2/sub/c.js.map",
+    ],
+)
+
+sh_test(
+    name = "check_out_dir_outputs",
+    srcs = ["check_outputs.sh"],
+    args = ["out2"],
+    data = [":compile"],
+)
+
+swc(
+    name = "compile3",
+    srcs = [
+        "sub/c.ts",
+    ],
+    out_dir = "out3",
+    root_dir = "sub",
+    source_maps = True,
+    swcrc = ".swcrc",
+)
+
+build_test(
+    name = "root_out_predeclared_test",
+    targets = [
+        "out3/c.js",
+        "out3/c.js.map",
+    ],
+)

--- a/examples/genrule/check_outputs.sh
+++ b/examples/genrule/check_outputs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit
+
+dir="genrule"
+if $1; then
+  dir="genrule/$1"
+fi
+
+cd "$TEST_SRCDIR/$TEST_WORKSPACE/$(dirname $TEST_TARGET)"
+
+grep "export var a" $dir/a.js
+grep "sourceMappingURL=a.js.map" $dir/a.js
+grep -v --fixed-strings '"sourceRoot"' $dir/a.js.map
+grep --fixed-strings '"sources":["a.ts"]' $dir/a.js.map
+
+grep "export var b" $dir/b.js
+grep "sourceMappingURL=b.js.map" $dir/b.js
+grep -v --fixed-strings '"sourceRoot"' $dir/b.js.map
+grep --fixed-strings '"sources":["b.ts"]' $dir/b.js.map
+
+grep "export var c" $dir/sub/c.js
+grep "sourceMappingURL=c.js.map" $dir/sub/c.js
+grep -v --fixed-strings '"sourceRoot"' $dir/sub/c.js.map
+grep --fixed-strings '"sources":["c.ts"]' $dir/sub/c.js.map

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -95,7 +95,7 @@ def _relative_to_package(path, ctx):
     return path
 
 # Copied from ts_lib.bzl
-# https://github.com/aspect-build/rules_ts/blob/v2.2.0/ts/private/ts_lib.bzl#L193-L229
+# https://github.com/aspect-build/rules_ts/blob/v3.1.0/ts/private/ts_lib.bzl#L193C1-L202C16
 # TODO: We should probably share code to avoid the implementations diverging and having different bugs
 def _replace_ext(f, ext_map):
     cur_ext = f[f.rindex("."):]
@@ -107,15 +107,16 @@ def _replace_ext(f, ext_map):
         return new_ext
     return None
 
-# https://github.com/aspect-build/rules_ts/blob/v2.2.0/ts/private/ts_lib.bzl#L203-L208
+# https://github.com/aspect-build/rules_ts/blob/v3.1.0/ts/private/ts_lib.bzl#L204-L210
 def _to_out_path(f, out_dir, root_dir):
+    f = f[f.find(":") + 1:]
     if root_dir:
         f = f.removeprefix(root_dir + "/")
     if out_dir:
         f = _join(out_dir, f)
     return f
 
-# https://github.com/aspect-build/rules_ts/blob/v2.2.0/ts/private/ts_lib.bzl#L161-L165
+# https://github.com/aspect-build/rules_ts/blob/v3.1.0/ts/private/ts_lib.bzl#L162-L166
 def _join(*elements):
     segments = [f for f in elements if f and f != "."]
     if len(segments):


### PR DESCRIPTION
Minor fix aligning with rules_ts while trying to reproduce #274

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
