### PR TITLE
fix: consider root dir for source maps paths

### DIFF
--- a/examples/root_dir/expected/a.js.map.golden
+++ b/examples/root_dir/expected/a.js.map.golden
@@ -1,5 +1,5 @@
 {
     "sources": [
-        "../../src/a.ts"
+        "../src/a.ts"
     ]
 }

--- a/examples/root_dir/expected/b.js.map.golden
+++ b/examples/root_dir/expected/b.js.map.golden
@@ -1,5 +1,5 @@
 {
     "sources": [
-        "../../src/b.ts"
+        "../src/b.ts"
     ]
 }

--- a/examples/root_dir/expected/sub/c.js.map.golden
+++ b/examples/root_dir/expected/sub/c.js.map.golden
@@ -1,5 +1,5 @@
 {
     "sources": [
-        "../../../src/sub/c.ts"
+        "../../src/sub/c.ts"
     ]
 }

--- a/examples/source_root/expected_subdir.js.map.golden
+++ b/examples/source_root/expected_subdir.js.map.golden
@@ -1,6 +1,6 @@
 {
     "sources": [
-        "../src/subdir.ts"
+        "src/subdir.ts"
     ],
     "sourceRoot": "../../../debug/source"
 }

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -193,7 +193,10 @@ def _calculate_source_file(ctx, src):
 
     # out of src subdir
     if src_pkg:
-        s = paths.join(s, "/".join([".." for _ in src_pkg.split("/")]))
+        src_pkg_depth = len(src_pkg.split("/"))
+        root_dir_depth = len(ctx.attr.root_dir.split("/")) if ctx.attr.root_dir else 0
+        effective_depth = max(0, src_pkg_depth - root_dir_depth)
+        s = paths.join(s, "/".join([".." for _ in range(effective_depth)]))
 
     # out of the out dir
     if ctx.attr.out_dir:


### PR DESCRIPTION
Fixes an issue where the `root_dir` was not considered when computing the paths in source maps. The issue is visible in the examples by checking the computed paths against the actual paths of the source files in the Bazel output directory.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
