### PR TITLE
fix: when src is not local, basename is not fully describing the filename

### DIFF
--- a/examples/source_root/expected.js.map.golden
+++ b/examples/source_root/expected.js.map.golden
@@ -1,6 +1,6 @@
 {
     "sources": [
-        "in.ts"
+        "examples/source_root/in.ts"
     ],
     "sourceRoot": "https://my-website.com/debug/source/"
 }

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -186,7 +186,7 @@ def _calculate_map_outs(srcs, source_maps, out_dir, root_dir):
 
 def _calculate_source_file(ctx, src):
     if not (ctx.attr.out_dir or ctx.attr.root_dir):
-        return src.basename
+        return src.short_path if ctx.attr.source_root else src.basename
 
     src_pkg = src.dirname[len(ctx.label.package) + 1:] if ctx.label.package else ""
     s = ""


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
