### PR TITLE
feat: upgrade default swc version to v1.7.40

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 docs/*.md
+examples/pnpm-lock.yaml
 **/expected.js
 **/expected.cjs
 **/expected_tsc

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "platforms", version = "0.0.7")
 swc = use_extension("@aspect_rules_swc//swc:extensions.bzl", "swc")
 swc.toolchain(
     name = "swc",
-    swc_version = "v1.6.6",
+    swc_version = "v1.7.40",
 )
 use_repo(swc, "swc_toolchains")
 

--- a/examples/plugins/BUILD.bazel
+++ b/examples/plugins/BUILD.bazel
@@ -18,7 +18,6 @@ swc_plugin(
     name = "npm_plugin",
     srcs = [
         # reference the location where the "@swc/plugin-transform-imports" npm package was linked in our root Bazel package.
-        ":node_modules/@swc/plugin-transform-imports",
         ":node_modules/@swc/plugin-transform-imports/dir",
     ],
     # optional plugin config, the JSON object for the plugin passed into jsc.experimental.plugins

--- a/examples/plugins/package.json
+++ b/examples/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@swc/plugin-transform-imports": "1.5.70"
+    "@swc/plugin-transform-imports": "^3.0.0"
   }
 }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -1,10 +1,11 @@
-lockfileVersion: "6.1"
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     dependencies:
       source-map-support:
@@ -13,7 +14,7 @@ importers:
     devDependencies:
       typescript:
         specifier: 5.2.2
-        version: registry.npmjs.org/typescript@5.2.2
+        version: 5.2.2
 
   generate_swcrc:
     devDependencies:
@@ -23,86 +24,62 @@ importers:
 
   plugins:
     devDependencies:
-      "@swc/plugin-transform-imports":
-        specifier: 1.5.70
-        version: 1.5.70
+      '@swc/plugin-transform-imports':
+        specifier: ^3.0.0
+        version: 3.0.4
 
 packages:
+
   /@fastify/deepmerge@1.3.0:
-    resolution:
-      {
-        integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==,
-      }
+    resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
     dev: true
 
-  /@swc/plugin-transform-imports@1.5.70:
-    resolution:
-      {
-        integrity: sha512-cERR7gMvqiLMWyS7wWGBPWW77Mz23ss/8iAfLj5V+6CdBGYfabpAmBmqR18mvJ2qGc1Dg1GHLPN8JcMXcX95JA==,
-      }
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+    dev: true
+
+  /@swc/plugin-transform-imports@3.0.4:
+    resolution: {integrity: sha512-ubmNyCgaXtRNstdU/rv33QGFt6i4YZM9mL1IrrMkVbCVC+2xFNN6SKaJUdcNHkzgLWumK8H29Xman3CAOtR1Jw==}
+    dependencies:
+      '@swc/counter': 0.1.3
     dev: true
 
   /buffer-from@1.1.2:
-    resolution:
-      {
-        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
-      }
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: false
 
   /joycon@3.1.1:
-    resolution:
-      {
-        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
     dev: true
 
   /jsonc-parser@3.2.0:
-    resolution:
-      {
-        integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==,
-      }
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
   /source-map-support@0.5.21:
-    resolution:
-      {
-        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
-      }
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: false
 
   /source-map@0.6.1:
-    resolution:
-      {
-        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /tsconfig-to-swcconfig@2.4.0:
-    resolution:
-      {
-        integrity: sha512-vT1hUG06TC3XCRQoina91VGH5HKfxYgA4hN2Ly0uNxHKNeCds++7aBE2Je62FUTKvvdkTpLjmynF8bzgYcDymA==,
-      }
+    resolution: {integrity: sha512-vT1hUG06TC3XCRQoina91VGH5HKfxYgA4hN2Ly0uNxHKNeCds++7aBE2Je62FUTKvvdkTpLjmynF8bzgYcDymA==}
     hasBin: true
     dependencies:
-      "@fastify/deepmerge": 1.3.0
+      '@fastify/deepmerge': 1.3.0
       joycon: 3.1.1
       jsonc-parser: 3.2.0
     dev: true
 
-  registry.npmjs.org/typescript@5.2.2:
-    resolution:
-      {
-        integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==,
-        registry: https://registry.npmjs.com/,
-        tarball: https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz,
-      }
-    name: typescript
-    version: 5.2.2
-    engines: { node: ">=14.17" }
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -38,10 +38,10 @@ load("//swc/private:versions.bzl", "TOOL_VERSIONS")
 # NB: we don't use the "most recent release" since swc has a history of often breaking Bazel usage
 # with subtle changes that get through their tests.
 # So instead, this reflects the latest version that is "known good" according to our test suite.
-LATEST_SWC_VERSION = "v1.6.6"
+LATEST_SWC_VERSION = "v1.7.40"
 
 # TODO(2.0): remove this alias
-LATEST_VERSION = LATEST_SWC_VERSION
+LATEST_VERSION = "v1.6.6"
 
 _DOC = "Fetch external dependencies needed to run the SWC cli"
 _ATTRS = {


### PR DESCRIPTION
Passes all tests with only minor modifications. Still using a manually specified+tested version instead of `LATEST[0]` for now.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The `LATEST_SWC_VERSION` has now been set to `v1.7.40`.

### Test plan

- Covered by existing test cases
