### PR TITLE
refactor: align js file extension logic with rules_ts

### DIFF
--- a/examples/allow_js/BUILD.bazel
+++ b/examples/allow_js/BUILD.bazel
@@ -6,7 +6,7 @@ load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
 # Runs `swc in.js > ../../bazel-bin/examples/js_outs/in.js`
 swc(
-    name = "compile",
+    name = "compile-js",
     srcs = ["in.js"],
 )
 
@@ -15,5 +15,27 @@ write_source_files(
     name = "test",
     # There is no pre-declared output of the "compile" rule because the input is .js
     # so the the target name is used instead of output file.
-    files = {"expected.js": ":compile"},
+    files = {"expected.js": ":compile-js"},
+)
+
+# Runs swc on all js files
+swc(
+    name = "compile-js-exts",
+    srcs = [
+        "in.cjs",
+        "in.d.ts",
+        "in.jsx",
+        "in.mjs",
+    ],
+    out_dir = "js_outs",
+)
+
+# Assert the extensions and output of each js file type via pre-declared outputs.
+write_source_files(
+    name = "test-x",
+    files = {
+        "expected.jsx": "js_outs/in.js",
+        "expected.mjs": "js_outs/in.mjs",
+        "expected.cjs": "js_outs/in.cjs",
+    },
 )

--- a/examples/allow_js/expected.cjs
+++ b/examples/allow_js/expected.cjs
@@ -1,0 +1,1 @@
+exports.a = "simple";

--- a/examples/allow_js/expected.jsx
+++ b/examples/allow_js/expected.jsx
@@ -1,0 +1,1 @@
+export var a = "simple";

--- a/examples/allow_js/expected.mjs
+++ b/examples/allow_js/expected.mjs
@@ -1,0 +1,1 @@
+export var a = "simple";

--- a/examples/allow_js/in.cjs
+++ b/examples/allow_js/in.cjs
@@ -1,0 +1,1 @@
+exports.a = "simple";

--- a/examples/allow_js/in.d.ts
+++ b/examples/allow_js/in.d.ts
@@ -1,0 +1,1 @@
+export const a: string;

--- a/examples/allow_js/in.jsx
+++ b/examples/allow_js/in.jsx
@@ -1,0 +1,1 @@
+export const a = "simple";

--- a/examples/allow_js/in.mjs
+++ b/examples/allow_js/in.mjs
@@ -1,0 +1,1 @@
+export const a = "simple";


### PR DESCRIPTION
Partially in preparation for https://github.com/aspect-build/rules_swc/pull/270 where I hope to also fix the issue demonstrated in https://github.com/jfirebaugh/rules_ts/commit/42bb97dad0abc4d3c0c8f701ee0e88a885a346a6.

This does fix one minor/uncommon issue when you have multiple input+output files only differing in extension (`in.{jsx,mjs,cjs}`), see the `alt_js_out` change.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
