### PR TITLE
chore: upgrade bazel-lib to include windows tar fix

### DIFF
--- a/.aspect/bazelrc/convenience.bazelrc
+++ b/.aspect/bazelrc/convenience.bazelrc
@@ -3,7 +3,7 @@
 build --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
-# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# fail. This makes the log noisier in exchange for reducing the time-to-feedback on test failures for
 # users.
 # Docs: https://bazel.build/docs/user-manual#test-output
 test --test_output=errors

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -24,7 +24,7 @@ test --test_verbose_timeout_warnings
 # Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
 # notices when a directory changes, if you have a directory listed in the srcs of some target.
 # Recommended when using
-# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md) and
 # [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
 # inputs to copy_directory actions.
 # Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
@@ -42,17 +42,6 @@ test --incompatible_exclusive_test_sandboxed
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
 build --incompatible_strict_action_env
 
-# Propagate tags from a target declaration to the actions' execution requirements.
-# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
-# get propagated to actions created by the rule.
-# Without this option, you rely on rules authors to manually check the tags you passed
-# and apply relevant ones to the actions they create.
-# See https://github.com/bazelbuild/bazel/issues/8830 for details.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
-build --experimental_allow_tags_propagation
-fetch --experimental_allow_tags_propagation
-query --experimental_allow_tags_propagation
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the
@@ -68,7 +57,7 @@ build --incompatible_default_to_explicit_init_py
 common --incompatible_disallow_empty_glob
 
 # Always download coverage files for tests from the remote cache. By default, coverage files are not
-# downloaded on test result cahce hits when --remote_download_minimal is enabled, making it impossible
+# downloaded on test result cache hits when --remote_download_minimal is enabled, making it impossible
 # to generate a full coverage report.
 # Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
 # detching remote cache results

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -1,9 +1,3 @@
-# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
-# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
-# Bazel doesn't write to the local disk cache as it treats as a remote cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
-build --incompatible_remote_results_ignore_disk
-
 # Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
 # Save time on Sandbox creation and deletion when many of the same kind of action run during the
 # build.
@@ -11,10 +5,15 @@ build --incompatible_remote_results_ignore_disk
 # Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
 build --experimental_reuse_sandbox_directories
 
-# Do not build runfiles symlink forests for external repositories under
-# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
-# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
-# default in the future. Note, some rules may fail under this flag, please file issues with the rule
-# author.
-# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
-build --nolegacy_external_runfiles
+# Avoid creating a runfiles tree for binaries or tests until it is needed.
+# Docs: https://bazel.build/reference/command-line-reference#flag--build_runfile_links
+# See https://github.com/bazelbuild/bazel/issues/6627
+#
+# This may break local workflows that `build` a binary target, then run the resulting program
+# outside of `bazel run`. In those cases, the script will need to call
+# `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
+build --nobuild_runfile_links
+
+# Needed prior to Bazel 8; see
+# https://github.com/bazelbuild/bazel/issues/20577
+coverage --build_runfile_links

--- a/.github/workflows/bazel6.bazelrc
+++ b/.github/workflows/bazel6.bazelrc
@@ -20,8 +20,35 @@ build --noexperimental_action_cache_store_output_metadata
 # when local debugging.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
 # NB: This flag is in bazel6.bazelrc as when used in Bazel 7 is has been observed to break
-# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/aspect-build/bazel-lib/pull/711
+# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/bazel-contrib/bazel-lib/pull/711
 # for more info.
 build --noexperimental_check_output_files
 fetch --noexperimental_check_output_files
 query --noexperimental_check_output_files
+
+# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
+# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
+# Bazel doesn't write to the local disk cache as it treats as a remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+# NB: This flag is in bazel6.bazelrc because it became a no-op in Bazel 7 and has been removed
+# in Bazel 8.
+build --incompatible_remote_results_ignore_disk
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles

--- a/.github/workflows/bazel7.bazelrc
+++ b/.github/workflows/bazel7.bazelrc
@@ -1,11 +1,23 @@
 # Speed up all builds by not checking if external repository files have been modified.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java#L244
-build --noexperimental_check_external_repository_files
-fetch --noexperimental_check_external_repository_files
-query --noexperimental_check_external_repository_files
+common --noexperimental_check_external_repository_files
+
+# Don't report when the root module's lower bound for a dependency happens to be less than the resolved version.
+# This is expected and should NOT prompt an engineer to update our lower bound to match.
+# WARNING: For repository 'aspect_bazel_lib', the root module requires module version aspect_bazel_lib@1.30.2,
+# but got aspect_bazel_lib@1.31.2 in the resolved dependency graph.
+common --check_direct_dependencies=off
 
 # Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
 # Save time on Sandbox creation and deletion when many of the same kind of action run during the
 # build.
 # Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
 build --reuse_sandbox_directories
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
+bazel_dep(name = "aspect_bazel_lib", version = "2.11.0")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")  # Note: only used for provider symbols, we don't spawn nodejs actions
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.7")

--- a/examples/filegroup/BUILD.bazel
+++ b/examples/filegroup/BUILD.bazel
@@ -25,4 +25,8 @@ sh_test(
     name = "check_outputs",
     srcs = ["check_outputs.sh"],
     data = [":compile"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/examples/genrule/BUILD.bazel
+++ b/examples/genrule/BUILD.bazel
@@ -48,6 +48,10 @@ sh_test(
     name = "check_outputs",
     srcs = ["check_outputs.sh"],
     data = [":compile"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 swc(
@@ -77,6 +81,10 @@ sh_test(
     srcs = ["check_outputs.sh"],
     args = ["out2"],
     data = [":compile"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 swc(

--- a/swc/dependencies.bzl
+++ b/swc/dependencies.bzl
@@ -21,9 +21,9 @@ def rules_swc_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "6d758a8f646ecee7a3e294fbe4386daafbe0e5966723009c290d493f227c390b",
-        strip_prefix = "bazel-lib-2.7.7",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz",
+        integrity = "sha256-yW22ndJxSjfzKYM4oaQrJ+OiaWw7Nt1EQbm/ehoSvuA=",
+        strip_prefix = "bazel-lib-2.11.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Fix windows before tagging a release, see [failures at HEAD](https://github.com/aspect-build/rules_swc/actions/runs/14205075208/job/39800834303) 

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Upgrade bazel-lib to include https://github.com/bazel-contrib/bazel-lib/pull/969

### Test plan

- Manual testing; include `windows` in the branch name to trigger windows CI
