### PR TITLE
fix: add support for `swc_version_from` to bzlmod extension

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -55,7 +55,7 @@ Users can avoid this macro and do these steps themselves, if they want more cont
 | :------------- | :------------- | :------------- |
 | <a id="swc_register_toolchains-name"></a>name |  base name for all created repos; we recommend `swc`   |  none |
 | <a id="swc_register_toolchains-swc_version"></a>swc_version |  version of the swc project, from https://github.com/swc-project/swc/releases Exactly one of `swc_version` or `swc_version_from` must be set.   |  `None` |
-| <a id="swc_register_toolchains-swc_version_from"></a>swc_version_from |  label of a json file (typically `package.json`) which declares an exact `@swc/core` version in a dependencies or devDependencies property. Exactly one of `swc_version` or `swc_version_from` must be set.   |  `None` |
+| <a id="swc_register_toolchains-swc_version_from"></a>swc_version_from |  label of a json file which declares an `@swc/core` version.<br><br>This may be a `package.json` file, with "@swc/core" in the dependencies or devDependencies property, and the version exactly specified.<br><br>With rules_js v1.32.0 or greater, it may also be a `resolved.json` file produced by `npm_translate_lock`, such as `@npm//path/to/linked:@swc/core/resolved.json`<br><br>Exactly one of `swc_version` or `swc_version_from` must be set.   |  `None` |
 | <a id="swc_register_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  `True` |
 | <a id="swc_register_toolchains-kwargs"></a>kwargs |  passed to each swc_repositories call   |  none |
 

--- a/e2e/smoke/.bazelignore
+++ b/e2e/smoke/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/smoke/.npmrc
+++ b/e2e/smoke/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -6,9 +6,19 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
+bazel_dep(name = "aspect_rules_js", version = "2.0.0")
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")
+
 # Optional: specify a custom swc toolchain instead of the default
 swc = use_extension("@aspect_rules_swc//swc:extensions.bzl", "swc", dev_dependency = True)
 swc.toolchain(
     name = "swc",
-    swc_version = "v1.3.78",
+    swc_version_from = "@npm//:@swc/core/resolved.json",
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -7,6 +7,7 @@ local_path_override(
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
+
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(
     name = "npm",

--- a/e2e/smoke/package.json
+++ b/e2e/smoke/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "@swc/core": "~1.11.0"
+    }
+}

--- a/e2e/smoke/pnpm-lock.yaml
+++ b/e2e/smoke/pnpm-lock.yaml
@@ -1,0 +1,137 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+devDependencies:
+  '@swc/core':
+    specifier: ~1.11.0
+    version: 1.11.16
+
+packages:
+
+  /@swc/core-darwin-arm64@1.11.16:
+    resolution: {integrity: sha512-l6uWMU+MUdfLHCl3dJgtVEdsUHPskoA4BSu0L1hh9SGBwPZ8xeOz8iLIqZM27lTuXxL4KsYH6GQR/OdQ/vhLtg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.11.16:
+    resolution: {integrity: sha512-TH0IW8Ao1WZ4ARFHIh29dAQHYBEl4YnP74n++rjppmlCjY+8v3s5nXMA7IqxO3b5LVHyggWtU4+46DXTyMJM7g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.11.16:
+    resolution: {integrity: sha512-2IxD9t09oNZrbv37p4cJ9cTHMUAK6qNiShi9s2FJ9LcqSnZSN4iS4hvaaX6KZuG54d58vWnMU7yycjkdOTQcMg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.11.16:
+    resolution: {integrity: sha512-AYkN23DOiPh1bf3XBf/xzZQDKSsgZTxlbyTyUIhprLJpAAAT0ZCGAUcS5mHqydk0nWQ13ABUymodvHoroutNzw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.11.16:
+    resolution: {integrity: sha512-n/nWXDRCIhM51dDGELfBcTMNnCiFatE7LDvsbYxb7DJt1HGjaCNvHHCKURb/apJTh/YNtWfgFap9dbsTgw8yPA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.11.16:
+    resolution: {integrity: sha512-xr182YQrF47n7Awxj+/ruI21bYw+xO/B26KFVnb+i3ezF9NOhqoqTX+33RL1ZLA/uFTq8ksPZO/y+ZVS/odtQA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.11.16:
+    resolution: {integrity: sha512-k2JBfiwWfXCIKrBRjFO9/vEdLSYq0QLJ+iNSLdfrejZ/aENNkbEg8O7O2GKUSb30RBacn6k8HMfJrcPLFiEyCQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.11.16:
+    resolution: {integrity: sha512-taOb5U+abyEhQgex+hr6cI48BoqSvSdfmdirWcxprIEUBHCxa1dSriVwnJRAJOFI9T+5BEz88by6rgbB9MjbHA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.11.16:
+    resolution: {integrity: sha512-b7yYggM9LBDiMY+XUt5kYWvs5sn0U3PXSOGvF3CbLufD/N/YQiDcYON2N3lrWHYL8aYnwbuZl45ojmQHSQPcdA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.11.16:
+    resolution: {integrity: sha512-/ibq/YDc3B5AROkpOKPGxVkSyCKOg+ml8k11RxrW7FAPy6a9y5y9KPcWIqV74Ahq4RuaMNslTQqHWAGSm0xJsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.11.16:
+    resolution: {integrity: sha512-wgjrJqVUss8Lxqilg0vkiE0tkEKU3mZkoybQM1Ehy+PKWwwB6lFAwKi20cAEFlSSWo8jFR8hRo19ZELAoLDowg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '*'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.21
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.11.16
+      '@swc/core-darwin-x64': 1.11.16
+      '@swc/core-linux-arm-gnueabihf': 1.11.16
+      '@swc/core-linux-arm64-gnu': 1.11.16
+      '@swc/core-linux-arm64-musl': 1.11.16
+      '@swc/core-linux-x64-gnu': 1.11.16
+      '@swc/core-linux-x64-musl': 1.11.16
+      '@swc/core-win32-arm64-msvc': 1.11.16
+      '@swc/core-win32-ia32-msvc': 1.11.16
+      '@swc/core-win32-x64-msvc': 1.11.16
+    dev: true
+
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+    dev: true
+
+  /@swc/types@0.1.21:
+    resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: true

--- a/swc/extensions.bzl
+++ b/swc/extensions.bzl
@@ -5,8 +5,7 @@ load(":repositories.bzl", "swc_register_toolchains")
 swc_toolchain = tag_class(attrs = {
     "name": attr.string(doc = "Base name for generated repositories"),
     "swc_version": attr.string(doc = "Explicit version of @swc/core. If provided, the package.json is not read."),
-    # TODO: support this variant
-    # "swc_version_from": attr.string(doc = "Location of package.json which may have a version for @swc/core."),
+    "swc_version_from": attr.label(doc = "Location of package.json which may have a version for @swc/core."),
 })
 
 default_repository = "swc"
@@ -23,7 +22,7 @@ def _toolchain_extension(module_ctx):
                     # Prioritize the root-most registration of the default toolchain version and
                     # ignore any further registrations (modules are processed breadth-first)
                     continue
-                if toolchain.swc_version == registrations[toolchain.name]:
+                if toolchain.swc_version == registrations[toolchain.name].swc_version and toolchain.swc_version_from == registrations[toolchain.name].swc_version_from:
                     # No problem to register a matching toolchain twice
                     continue
                 fail("Multiple conflicting toolchains declared for name {} ({} and {}".format(
@@ -32,11 +31,16 @@ def _toolchain_extension(module_ctx):
                     registrations[toolchain.name],
                 ))
             else:
-                registrations[toolchain.name] = toolchain.swc_version
-    for name, swc_version in registrations.items():
+                registrations[toolchain.name] = struct(
+                    swc_version = toolchain.swc_version,
+                    swc_version_from = toolchain.swc_version_from,
+                )
+
+    for name, registration in registrations.items():
         swc_register_toolchains(
             name = name,
-            swc_version = swc_version,
+            swc_version = registration.swc_version if registration.swc_version else None,
+            swc_version_from = registration.swc_version_from if registration.swc_version_from else None,
             register = False,
         )
 

--- a/swc/extensions.bzl
+++ b/swc/extensions.bzl
@@ -39,8 +39,8 @@ def _toolchain_extension(module_ctx):
     for name, registration in registrations.items():
         swc_register_toolchains(
             name = name,
-            swc_version = registration.swc_version if registration.swc_version else None,
-            swc_version_from = registration.swc_version_from if registration.swc_version_from else None,
+            swc_version = registration.swc_version,
+            swc_version_from = registration.swc_version_from,
             register = False,
         )
 

--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -71,6 +71,7 @@ def _determine_version(rctx):
 
     json_path = rctx.path(rctx.attr.swc_version_from)
     p = json.decode(rctx.read(json_path))
+
     # Allow use of "resolved.json", see https://github.com/aspect-build/rules_js/pull/1221
     if "$schema" in p.keys() and p["$schema"] == "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock":
         v = p["version"]

--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -71,7 +71,10 @@ def _determine_version(rctx):
 
     json_path = rctx.path(rctx.attr.swc_version_from)
     p = json.decode(rctx.read(json_path))
-    if "devDependencies" in p.keys() and _NPM_PKG in p["devDependencies"]:
+    # Allow use of "resolved.json", see https://github.com/aspect-build/rules_js/pull/1221
+    if "$schema" in p.keys() and p["$schema"] == "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock":
+        v = p["version"]
+    elif "devDependencies" in p.keys() and _NPM_PKG in p["devDependencies"]:
         v = p["devDependencies"][_NPM_PKG]
     elif "dependencies" in p.keys() and _NPM_PKG in p["dependencies"]:
         v = p["dependencies"][_NPM_PKG]

--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -150,8 +150,15 @@ def swc_register_toolchains(name, swc_version = None, swc_version_from = None, r
 
     Args:
         name: base name for all created repos; we recommend `swc`
-        swc_version_from: label of a json file (typically `package.json`) which declares an exact `@swc/core` version
-            in a dependencies or devDependencies property.
+        swc_version_from: label of a json file which declares an `@swc/core` version.
+
+            This may be a `package.json` file, with "@swc/core" in the dependencies or
+            devDependencies property, and the version exactly specified.
+
+            With rules_js v1.32.0 or greater, it may also be a `resolved.json` file
+            produced by `npm_translate_lock`, such as
+            `@npm//path/to/linked:@swc/core/resolved.json`
+
             Exactly one of `swc_version` or `swc_version_from` must be set.
         swc_version: version of the swc project, from https://github.com/swc-project/swc/releases
             Exactly one of `swc_version` or `swc_version_from` must be set.


### PR DESCRIPTION
Add support for `swc_version_from` to bzlmod extension.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add support for `swc_version_from` to bzlmod extension.

### Test plan

- Covered by existing test cases