### PR TITLE
Remove bad incompatible_use_toolchain_transition reference.

### DIFF
--- a/swc/private/resolved_toolchain.bzl
+++ b/swc/private/resolved_toolchain.bzl
@@ -22,5 +22,4 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_rules_swc//swc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
Bazel doesn't recognize this as of https://github.com/bazelbuild/bazel/commit/f53608ac3dbfd02cecb4bb78a138badb0d84e311.

This causes @bazelbuild/examples CI failure: https://github.com/bazelbuild/examples/issues/610.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: see https://github.com/bazelbuild/examples/issues/610.
