### PR TITLE
fix: handle `@swc/helpers` peer dependency in `resolved.json`

### DIFF
--- a/swc/repositories.bzl
+++ b/swc/repositories.bzl
@@ -75,7 +75,8 @@ def determine_version(rctx, swc_version, swc_version_from):
 
     # Allow use of "resolved.json", see https://github.com/aspect-build/rules_js/pull/1221
     if "$schema" in p.keys() and p["$schema"] == "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock":
-        v = p["version"]
+        # PNPM encodes peer dependencies in the version string that we need to strip out, e.g. "1.15.33(@swc/helpers@0.5.21)"
+        v = p["version"].split("(")[0]
     elif "devDependencies" in p.keys() and _NPM_PKG in p["devDependencies"]:
         v = p["devDependencies"][_NPM_PKG]
     elif "dependencies" in p.keys() and _NPM_PKG in p["dependencies"]:


### PR DESCRIPTION
I hit an error like this when I added a dependency on `@swc/helpers` to our repository that specifies `swc_version_from = "@npm//:@swc/core/resolved.json"`

```
  INFO: Invocation ID: cd335b68-f9f6-4681-9ce9-f51c2991028e
  ERROR: /Users/wburgin/Library/Caches/bazel/_bazel_wburgin/c90b2577a3a8b9dfa40cf73d4474371f/external/aspect_rules_swc+/swc/repositories.bzl:86:13: Traceback (most recent call last):
          File "/Users/wburgin/Library/Caches/bazel/_bazel_wburgin/c90b2577a3a8b9dfa40cf73d4474371f/external/aspect_rules_swc+/swc/extensions.bzl", line 32, column 44, in _toolchain_extension
                  swc_version = determine_version(module_ctx, toolchain.swc_version, toolchain.swc_version_from)
          File "/Users/wburgin/Library/Caches/bazel/_bazel_wburgin/c90b2577a3a8b9dfa40cf73d4474371f/external/aspect_rules_swc+/swc/repositories.bzl", line 86, column 13, in determine_version
                  fail("{} version in package.json must be exactly specified, not a semver range: {}.\n".format(_NPM_PKG, v) +
  Error in fail: @swc/core version in package.json must be exactly specified, not a semver range: 1.15.33(@swc/helpers@0.5.21).
  You can supply an exact 'swc_version' attribute to 'swc_register_toolchains' to bypass this check.
  ERROR: Analysis of target '//build/project-references-cli:project-references-cli' failed; build aborted: error evaluating module extension @@aspect_rules_swc+//swc:extensions.bzl%swc
  INFO: Elapsed time: 0.978s, Critical Path: 0.00s
  INFO: 1 process: 1 internal.
  ERROR: Build did NOT complete successfully
  FAILED:
      Fetching module extension @@aspect_rules_swc+//swc:extensions.bzl%swc; starting
```

Here's what that `resolved.json` looks like: 

```json
{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==","version":"1.15.33(@swc/helpers@0.5.21)"}
```

It looks like rules_js 2.x used a different syntax for `version`: `1.11.16_at_swc_helpers_0.5.23` -- is it worth trying to handle that here as well? 

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - Add a dependency on `@swc/helpers` to `e2e/smoke/package.json` 
  - Run `pnpm i`
  - Run `bazel test :all`
    <img width="2354" height="1522" alt="image" src="https://github.com/user-attachments/assets/4b1569b5-9da6-499f-aad9-6a433cb3d96a" />
