### PR TITLE
refactor: drop redundant sourceMaps setdefault for dict-form swcrc

### DIFF
--- a/examples/rcdict/BUILD.bazel
+++ b/examples/rcdict/BUILD.bazel
@@ -1,5 +1,6 @@
 "Showcases how to specify the SWC configuration file as a dict"
 
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 
@@ -31,4 +32,24 @@ write_source_files(
         "expected_es5.js": ":es5/in.js",
         "expected_es2015.js": ":es2015/in.js",
     },
+)
+
+# The source_maps attribute alone drives source map emission; a dict config
+# does not need a sourceMaps entry.
+swc(
+    name = "es5_maps",
+    srcs = ["in.ts"],
+    out_dir = "es5_maps",
+    source_maps = True,
+    swcrc = {
+        "jsc": {
+            "target": "es5",
+        },
+    },
+)
+
+assert_contains(
+    name = "test_maps",
+    actual = "es5_maps/in.js",
+    expected = "//# sourceMappingURL=in.js.map",
 )

--- a/swc/defs.bzl
+++ b/swc/defs.bzl
@@ -84,7 +84,6 @@ def swc(name, srcs, args = [], data = [], plugins = [], output_dir = False, swcr
         if file_exists(to_label(":.swcrc")):
             swcrc = to_label(":.swcrc")
     elif type(swcrc) == type(dict()):
-        swcrc.setdefault("sourceMaps", source_maps)
         rcfile = "{}_swcrc.json".format(name)
         write_file(
             name = "_gen_swcrc_" + name,


### PR DESCRIPTION
The rule always passes --source-maps with the same attribute value, so copying that value into the generated config never changes behavior: when the dict lacks the key, the CLI flag supplies the identical value, and when the dict sets it explicitly, setdefault never touched it.

Verified empirically with a new rcdict case combining a dict config with source_maps = True: the emitted .js and .js.map are byte-identical with and without the setdefault, and the whole example suite passes. As a bonus, the macro no longer mutates the caller's swcrc dict.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
