### PR TITLE
fix: pass dict-form swcrc as --config-json instead of writing a file

### DIFF
--- a/examples/generate_swcrc/BUILD.bazel
+++ b/examples/generate_swcrc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains", "assert_json_matches")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -41,5 +42,32 @@ assert_json_matches(
 assert_contains(
     name = "test_paths_import",
     actual = "app/main.js",
+    expected = 'from "../lib/utils/utils.js"',
+)
+
+# With copy_srcs_to_bin = False, srcs are transpiled in place (no per-src copy action).
+# A `jsc.baseUrl` is resolved relative to the generated swcrc's output location, so it
+# must step over bazel-out/<config>/bin and the package path back into the source tree.
+jq(
+    name = "write_swcrc_execroot",
+    srcs = [":write_swcrc"],
+    out = ".swcrc_execroot",
+    filter = '.jsc.baseUrl = "../../../../../examples/generate_swcrc"',
+)
+
+swc(
+    name = "compile_no_copy",
+    srcs = glob([
+        "app/**",
+        "lib/**",
+    ]),
+    copy_srcs_to_bin = False,
+    out_dir = "no_copy",
+    swcrc = ".swcrc_execroot",
+)
+
+assert_contains(
+    name = "test_paths_import_no_copy",
+    actual = "no_copy/app/main.js",
     expected = 'from "../lib/utils/utils.js"',
 )

--- a/examples/paths/BUILD.bazel
+++ b/examples/paths/BUILD.bazel
@@ -3,7 +3,7 @@
 Note that this example also depends on the setup in /WORKSPACE at the root of this repository.
 """
 
-load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains", "assert_json_matches")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@npm//examples:typescript/package_json.bzl", "bin")
@@ -12,6 +12,30 @@ load("@npm//examples:typescript/package_json.bzl", "bin")
 swc(
     name = "compile",
     srcs = glob(["**/*.ts"]),
+)
+
+# A relative jsc.baseUrl must also work when the config is a dict: swc anchors
+# a relative baseUrl at the config file location, which does not exist for
+# configuration passed on the command line.
+swc(
+    name = "compile_dict",
+    srcs = glob(["**/*.ts"]),
+    out_dir = "dict",
+    swcrc = {
+        "jsc": {
+            "parser": {"syntax": "typescript"},
+            "target": "es2021",
+            "baseUrl": "./src",
+            "paths": {"@modules/*": ["./modules/*"]},
+        },
+        "module": {"type": "commonjs"},
+    },
+)
+
+assert_contains(
+    name = "test_dict_paths",
+    actual = "dict/src/index.js",
+    expected = 'require("./modules/moduleA")',
 )
 
 # Produce a folder of the transpiled outputs of `tsc`.

--- a/examples/plugins/BUILD.bazel
+++ b/examples/plugins/BUILD.bazel
@@ -5,6 +5,7 @@ See https://github.com/swc-project/plugins
 
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_swc//swc:defs.bzl", "swc", "swc_plugin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -102,4 +103,22 @@ write_source_files(
         "expected_rc.js_": ":rc/in.js",
         "expected_rcdict.js_": ":rcdict/in.js",
     },
+)
+
+# Regression test: plugins combined with other rule-supplied configuration
+# (here emit_isolated_dts) must not clobber each other. swcx does not merge
+# repeated --config-json arguments — the last one silently wins — so the rule
+# must pass all of its configuration in a single --config-json.
+swc(
+    name = "plugin_with_dts",
+    srcs = ["dts.ts"],
+    emit_isolated_dts = True,
+    out_dir = "plugin_with_dts",
+    plugins = [":npm_plugin"],
+)
+
+assert_contains(
+    name = "test_plugin_with_dts",
+    actual = "plugin_with_dts/dts.js",
+    expected = 'from "lodash/map"',
 )

--- a/examples/plugins/dts.ts
+++ b/examples/plugins/dts.ts
@@ -1,0 +1,5 @@
+import { map } from "lodash";
+
+export function useMap(): string {
+  return String(map);
+}

--- a/swc/defs.bzl
+++ b/swc/defs.bzl
@@ -32,6 +32,25 @@ for example to set your own output labels for `js_outs`.
     toolchains = _swc_lib.toolchains,
 )
 
+def _config_resolves_paths(config):
+    """Whether a configuration dict uses swc's path-resolution options.
+
+    swc anchors a relative `jsc.baseUrl` at the location of the config file it
+    was loaded from. Since a config dict is written to a generated file in the
+    output tree, srcs must be copied to the output tree to share a tree with
+    it, otherwise the `jsc.paths` resolver emits imports routed through the
+    filesystem root. Configs without these options resolve no paths at all
+    and their srcs can be transpiled in place.
+
+    Args:
+        config: an swcrc configuration dict
+
+    Returns:
+        True if the config resolves paths relative to its own location
+    """
+    jsc = config.get("jsc", {})
+    return "baseUrl" in jsc or "paths" in jsc
+
 def swc(name, srcs, args = [], data = [], plugins = [], output_dir = False, swcrc = None, source_maps = False, out_dir = None, root_dir = None, default_ext = ".js", allow_js = True, **kwargs):
     """Execute the SWC compiler
 
@@ -84,6 +103,10 @@ def swc(name, srcs, args = [], data = [], plugins = [], output_dir = False, swcr
         if file_exists(to_label(":.swcrc")):
             swcrc = to_label(":.swcrc")
     elif type(swcrc) == type(dict()):
+        # Skip the per-src copy to bin unless the config requires the srcs to
+        # share a tree with the generated config file.
+        kwargs.setdefault("copy_srcs_to_bin", _config_resolves_paths(swcrc))
+
         rcfile = "{}_swcrc.json".format(name)
         write_file(
             name = "_gen_swcrc_" + name,

--- a/swc/private/swc.bzl
+++ b/swc/private/swc.bzl
@@ -88,6 +88,17 @@ or source file extensions.""",
 If False, only TypeScript sources will be transpiled.""",
         default = True,
     ),
+    "copy_srcs_to_bin": attr.bool(
+        doc = """Whether to copy srcs to the output tree when the swcrc config is a generated file.
+
+The copy keeps srcs in the same tree as the config, as required by a `jsc.baseUrl`
+anchored at the config location, at the cost of one extra action per source file.
+
+Set to False to transpile srcs in place. This is always safe when the config does not
+use `jsc.baseUrl`/`jsc.paths`; when it does, the generated config must anchor
+`jsc.baseUrl` back at the source tree, e.g. `"../../../../../<package path>"`.""",
+        default = True,
+    ),
 }
 
 _outputs = {
@@ -308,6 +319,10 @@ def _swc_impl(ctx):
         args.add("--config-file", ctx.file.swcrc)
         inputs.append(ctx.file.swcrc)
 
+    # Rule-supplied config options, merged into a single --config-json below
+    # since swcx only applies the last --config-json argument.
+    config = None
+
     # Add user specified arguments *before* rule supplied arguments
     args.add_all(ctx.attr.args)
 
@@ -317,16 +332,12 @@ def _swc_impl(ctx):
 
     if ctx.attr.plugins:
         plugin_cache = [ctx.actions.declare_directory("{}_plugin_cache".format(ctx.label.name))]
-        plugin_args = ["--config-json", json.encode({
-            "jsc": {
-                "experimental": {
-                    # TODO: .path breaks 'supports-path-mapping'
-                    "cacheRoot": plugin_cache[0].path,
-                    # TODO: .path breaks 'supports-path-mapping'
-                    "plugins": [["./" + p[DefaultInfo].files.to_list()[0].path, json.decode(p[SwcPluginConfigInfo].config)] for p in ctx.attr.plugins],
-                },
-            },
-        })]
+        plugins_config = {
+            # TODO: .path breaks 'supports-path-mapping'
+            "cacheRoot": plugin_cache[0].path,
+            # TODO: .path breaks 'supports-path-mapping'
+            "plugins": [["./" + p[DefaultInfo].files.to_list()[0].path, json.decode(p[SwcPluginConfigInfo].config)] for p in ctx.attr.plugins],
+        }
 
         null_file = "NUL" if platform_utils.host_platform_is_windows() else "/dev/null"
 
@@ -334,7 +345,7 @@ def _swc_impl(ctx):
         _swc_action(
             ctx,
             swc_toolchain.swcinfo.swc_binary,
-            arguments = ["compile"] + plugin_args + ["--source-maps", "false", "--out-file", null_file, null_file],
+            arguments = ["compile", "--config-json", json.encode({"jsc": {"experimental": plugins_config}}), "--source-maps", "false", "--out-file", null_file, null_file],
             inputs = inputs + ctx.files.plugins,
             outputs = plugin_cache,
             execution_requirements = {"supports-path-mapping": "1"},
@@ -342,16 +353,18 @@ def _swc_impl(ctx):
 
         inputs.extend(plugin_cache)
         inputs.extend(ctx.files.plugins)
-        args.add_all(plugin_args)
+
+        if config == None:
+            config = {}
+        config.setdefault("jsc", {}).setdefault("experimental", {}).update(plugins_config)
 
     if ctx.attr.emit_isolated_dts:
-        args.add_all(["--config-json", json.encode({
-            "jsc": {
-                "experimental": {
-                    "emitIsolatedDts": True,
-                },
-            },
-        })])
+        if config == None:
+            config = {}
+        config.setdefault("jsc", {}).setdefault("experimental", {})["emitIsolatedDts"] = True
+
+    if config != None:
+        args.add_all(["--config-json", json.encode(config)])
 
     if ctx.attr.output_dir:
         if len(ctx.attr.srcs) != 1:
@@ -399,9 +412,9 @@ def _swc_impl(ctx):
         if not ctx.attr.default_ext:
             custom_js_outs = [_relative_to_package(f, ctx, dir_cache) for f in ctx.outputs.js_outs]
 
-        # Keep srcs in the same tree as a generated swcrc so SWC's symlink-resolving
-        # `jsc.paths` resolver emits clean relative imports. See #325.
-        copy_srcs_to_bin = ctx.attr.swcrc and not ctx.file.swcrc.is_source
+        # Keep srcs in the same tree as a generated swcrc so its `jsc.baseUrl`/
+        # `jsc.paths` cover them, see the copy_srcs_to_bin docs.
+        copy_srcs_to_bin = ctx.attr.copy_srcs_to_bin and ctx.attr.swcrc and not ctx.file.swcrc.is_source
 
         source_file_dirname_cache = {}
 


### PR DESCRIPTION
swcx does not merge repeated --config-json arguments - the last one
silently wins - so plugins combined with emit_isolated_dts dropped the
plugin configuration: the build succeeded and emitted .d.ts files, but
the plugins never ran. Merge all rule-supplied config options into
exactly one --config-json. Covered by a new plugins example asserting
that a plugin transform and isolated dts emission apply together.

Also skip the per-src copy-to-bin (introduced in https://github.com/aspect-build/rules_swc/pull/360) for configs that
resolve no paths: a generated swcrc only requires srcs to share its
tree when jsc.baseUrl/jsc.paths anchor at the config file location.
A new copy_srcs_to_bin attribute makes this an explicit opt-out for
generated config files, and dict-form swcrc configs detect it
automatically. Covered by new regression tests for a dict config using
jsc.paths and for a generated config transpiling srcs in place.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
